### PR TITLE
Kotlin friendly names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.iml
+.idea
 target

--- a/ndarray/src/main/java/org/tensorflow/ndarray/Shape.java
+++ b/ndarray/src/main/java/org/tensorflow/ndarray/Shape.java
@@ -25,14 +25,12 @@ import java.util.List;
  * The shape of a Tensor or {@link NdArray}.
  *
  * <p>A {@code Shape} defines sizes along its axes. It may contain an unknown size for one of the
- * axes or may be totally unknown, in which case not even the number of axes is known. If the size of an axis is
- * unknown, {@link Shape#UNKNOWN_SIZE} should be used as its size.
+ * axes or may be totally unknown, in which case not even the number of axes is known. If the size
+ * of an axis is unknown, {@link Shape#UNKNOWN_SIZE} should be used as its size.
  */
 public final class Shape {
 
-  /**
-   * The size of an unknown axis or the total unknown size for an unknown Shape.
-   */
+  /** The size of an unknown axis or the total unknown size for an unknown Shape. */
   public static long UNKNOWN_SIZE = -1L;
 
   /**
@@ -57,8 +55,9 @@ public final class Shape {
    * Create a Shape representing a scalar or an N-dimensional value.
    *
    * <p>Creates a Shape representing a scalar or an N-dimensional value (N being at least 1), with
-   * the provided size for each dimension. A -1 indicates that the size of the corresponding dimension is unknown. If no
-   * sizes are provided, a Shape representing a scalar is created. For example:
+   * the provided size for each dimension. A -1 indicates that the size of the corresponding
+   * dimension is unknown. If no sizes are provided, a Shape representing a scalar is created. For
+   * example:
    *
    * <pre>{@code
    * // A 2-element vector.
@@ -77,8 +76,8 @@ public final class Shape {
    * Shape scalar = Shape.of()
    * }</pre>
    *
-   * @param dimensionSizes number of elements in each dimension of this shape, if any, or
-   *                       {@link Shape#UNKNOWN_SIZE} if unknown.
+   * @param dimensionSizes number of elements in each dimension of this shape, if any, or {@link
+   *     Shape#UNKNOWN_SIZE} if unknown.
    * @return a new shape
    */
   public static Shape of(long... dimensionSizes) {
@@ -94,8 +93,8 @@ public final class Shape {
    * <p>If {@link Shape#isUnknown()} is true or {@link Shape#hasUnknownDimension()} is true, {@link
    * Shape#UNKNOWN_SIZE} is returned.
    *
-   * @return The total number of elements a Tensor with this shape would have if it can be calculated, else {@link
-   * Shape#UNKNOWN_SIZE}.
+   * @return The total number of elements a Tensor with this shape would have if it can be
+   *     calculated, else {@link Shape#UNKNOWN_SIZE}.
    */
   public long size() {
     if (size == null) {
@@ -110,11 +109,13 @@ public final class Shape {
    * <p>If {@link Shape#isUnknown()} is true or the size of the dimension with the given index has
    * an unknown size, {@link Shape#UNKNOWN_SIZE} is returned.
    *
-   * @param i the index of the dimension to get the size for. If this Shape has a known number of dimensions, it must be
-   * &lt; {@link Shape#numDimensions()}. The index may be negative, in which case the position is counted from the end
-   * of the shape. E.g.: {@code size(-1)} returns the size of the last dimension, {@code size(-2)} the size of the
-   * second to last dimension etc.
-   * @return The size of the dimension with the given index if known, {@link Shape#UNKNOWN_SIZE} otherwise.
+   * @param i the index of the dimension to get the size for. If this Shape has a known number of
+   *     dimensions, it must be &lt; {@link Shape#numDimensions()}. The index may be negative, in
+   *     which case the position is counted from the end of the shape. E.g.: {@code size(-1)}
+   *     returns the size of the last dimension, {@code size(-2)} the size of the second to last
+   *     dimension etc.
+   * @return The size of the dimension with the given index if known, {@link Shape#UNKNOWN_SIZE}
+   *     otherwise.
    */
   public long get(int i) {
     if (dimensionSizes == null) {
@@ -127,15 +128,14 @@ public final class Shape {
   }
 
   /**
-   * Returns the number of dimensions of this Shape. -1 if unknown, 0 for a scalar, 1 for a vector, 2 for a matrix etc.
+   * Returns the number of dimensions of this Shape. -1 if unknown, 0 for a scalar, 1 for a vector,
+   * 2 for a matrix etc.
    */
   public int numDimensions() {
     return dimensionSizes != null ? dimensionSizes.length : -1;
   }
 
-  /**
-   * Returns whether one or more dimensions of this Shape have an unknown size.
-   */
+  /** Returns whether one or more dimensions of this Shape have an unknown size. */
   public boolean hasUnknownDimension() {
     if (dimensionSizes == null) {
       return true;
@@ -148,37 +148,29 @@ public final class Shape {
     return false;
   }
 
-  /**
-   * Returns whether this Shape represents a scalar.
-   */
+  /** Returns whether this Shape represents a scalar. */
   public boolean isScalar() {
     return dimensionSizes != null && dimensionSizes.length == 0;
   }
 
-  /**
-   * Returns whether this Shape is the shape of a vector.
-   */
+  /** Returns whether this Shape is the shape of a vector. */
   public boolean isVector() {
     return dimensionSizes != null && dimensionSizes.length == 1;
   }
 
-  /**
-   * Returns whether this Shape is the shape of a matrix
-   */
+  /** Returns whether this Shape is the shape of a matrix */
   public boolean isMatrix() {
     return dimensionSizes != null && dimensionSizes.length == 2;
   }
 
-  /**
-   * Returns whether the number of dimensions of this Shape is unknown.
-   */
+  /** Returns whether the number of dimensions of this Shape is unknown. */
   public boolean isUnknown() {
     return dimensionSizes == null;
   }
 
   /**
-   * Returns a defensive copy of the this Shape's axes. Changes to the returned array to not change this Shape's state.
-   * Returns null if {@link Shape#isUnknown()} is true.
+   * Returns a defensive copy of the this Shape's axes. Changes to the returned array to not change
+   * this Shape's state. Returns null if {@link Shape#isUnknown()} is true.
    */
   public long[] asArray() {
     if (this.dimensionSizes == null) {
@@ -189,8 +181,8 @@ public final class Shape {
   }
 
   /**
-   * Returns a defensive copy of the this Shape's axes. Changes to the returned list do not change this Shape's state.
-   * Returns null if {@link Shape#isUnknown()} is true.
+   * Returns a defensive copy of the this Shape's axes. Changes to the returned list do not change
+   * this Shape's state. Returns null if {@link Shape#isUnknown()} is true.
    */
   public List<Long> toListOrNull() {
     long[] array = asArray();
@@ -215,6 +207,7 @@ public final class Shape {
    * Equals implementation for Shapes. Two Shapes are considered equal iff:
    *
    * <p>
+   *
    * <ul>
    *   <li>the number of dimensions is defined and equal for both
    *   <li>the size of each dimension is defined and equal for both
@@ -241,9 +234,7 @@ public final class Shape {
     return false;
   }
 
-  /**
-   * Succinct description of the Shape meant for debugging.
-   */
+  /** Succinct description of the Shape meant for debugging. */
   @Override
   public String toString() {
     return Arrays.toString(dimensionSizes);
@@ -264,10 +255,13 @@ public final class Shape {
   }
 
   /**
-   * Returns an n-dimensional Shape with the dimensions matching the first n dimensions of this shape
+   * Returns an n-dimensional Shape with the dimensions matching the first n dimensions of this
+   * shape
    *
-   * @param n the number of leading dimensions to get, must be &lt;= than {@link Shape#numDimensions()}
-   * @return an n-dimensional Shape with the first n dimensions matching the first n dimensions of this Shape
+   * @param n the number of leading dimensions to get, must be &lt;= than {@link
+   *     Shape#numDimensions()}
+   * @return an n-dimensional Shape with the first n dimensions matching the first n dimensions of
+   *     this Shape
    */
   public Shape take(int n) {
     if (n > numDimensions()) {
@@ -279,9 +273,7 @@ public final class Shape {
     return Shape.of(newDimensions);
   }
 
-  /**
-   * Returns a new Shape, with this Shape's first dimension removed.
-   */
+  /** Returns a new Shape, with this Shape's first dimension removed. */
   public Shape tail() {
     if (dimensionSizes.length < 2) {
       return Shape.of();
@@ -290,10 +282,13 @@ public final class Shape {
   }
 
   /**
-   * Returns an n-dimensional Shape with the dimensions matching the last n dimensions of this Shape.
+   * Returns an n-dimensional Shape with the dimensions matching the last n dimensions of this
+   * Shape.
    *
-   * @param n the number of trailing dimensions to get, must be &lt;= than {@link Shape#numDimensions()}
-   * @return an n-dimensional shape with the dimensions matching the last n dimensions of this Shape, never null
+   * @param n the number of trailing dimensions to get, must be &lt;= than {@link
+   *     Shape#numDimensions()}
+   * @return an n-dimensional shape with the dimensions matching the last n dimensions of this
+   *     Shape, never null
    */
   public Shape takeLast(int n) {
     if (n > numDimensions()) {
@@ -306,8 +301,8 @@ public final class Shape {
   }
 
   /**
-   * Return a {@code end - begin} dimensional shape with dimensions matching this Shape from {@code begin} to {@code
-   * end}.
+   * Return a {@code end - begin} dimensional shape with dimensions matching this Shape from {@code
+   * begin} to {@code end}.
    *
    * @param begin Where to start the sub-shape.
    * @param end Where to end the sub-shape, exclusive.
@@ -316,7 +311,11 @@ public final class Shape {
   public Shape subShape(int begin, int end) {
     if (end > numDimensions()) {
       throw new ArrayIndexOutOfBoundsException(
-          "End index " + end + " out of bounds: shape only has " + numDimensions() + " dimensions.");
+          "End index "
+              + end
+              + " out of bounds: shape only has "
+              + numDimensions()
+              + " dimensions.");
     }
     if (begin < 0) {
       throw new ArrayIndexOutOfBoundsException(
@@ -329,11 +328,12 @@ public final class Shape {
   }
 
   /**
-   * Returns a new Shape, with a new first dimension added. In order for this call to succeed, {@link Shape#isUnknown()}
-   * must be {@code false}.
+   * Returns a new Shape, with a new first dimension added. In order for this call to succeed,
+   * {@link Shape#isUnknown()} must be {@code false}.
    *
    * @param firstDimension the dimension to prepend
-   * @return a new shape with the given dimension first, followed by this Shape's dimensions, never null
+   * @return a new shape with the given dimension first, followed by this Shape's dimensions, never
+   *     null
    */
   public Shape prepend(long firstDimension) {
     long[] newDimensions = new long[dimensionSizes.length + 1];
@@ -344,8 +344,8 @@ public final class Shape {
   }
 
   /**
-   * Returns a new Shape, with a new last dimension added. In order for this call to succeed, {@link Shape#isUnknown()}
-   * must be {@code false}.
+   * Returns a new Shape, with a new last dimension added. In order for this call to succeed, {@link
+   * Shape#isUnknown()} must be {@code false}.
    *
    * @param lastDimension the dimension to append
    * @return a new Shape with this Shape's dimensions followed by the given dimension, never null
@@ -359,11 +359,13 @@ public final class Shape {
   }
 
   /**
-   * Returns a new Shape, with another Shape's dimensions prepended. For both this Shape and the other Shape, {@link
-   * Shape#isUnknown()} must return false. E.g. {@code Shape.of(3,4).prepend(Shape.of(1,2)) => Shape.of(1,2,3,4) }
+   * Returns a new Shape, with another Shape's dimensions prepended. For both this Shape and the
+   * other Shape, {@link Shape#isUnknown()} must return false. E.g. {@code
+   * Shape.of(3,4).prepend(Shape.of(1,2)) => Shape.of(1,2,3,4) }
    *
    * @param other another Shape, must not be {@code null}, must not be unknown
-   * @return A new Shape consisting of the given Shape's dimensions followed by this Shape's dimensions, never null
+   * @return A new Shape consisting of the given Shape's dimensions followed by this Shape's
+   *     dimensions, never null
    */
   public Shape prepend(Shape other) {
     long[] newDimensions = new long[other.dimensionSizes.length + dimensionSizes.length];
@@ -374,11 +376,13 @@ public final class Shape {
   }
 
   /**
-   * Returns a new Shape, with another Shapes' dimensions appended. For both this Shape and the other Shape, {@link
-   * Shape#isUnknown()} must return false. E.g. @code Shape.of(3,4).append(Shape.of(1,2)) =&gt; Shape.of(3,4,1,2) }
+   * Returns a new Shape, with another Shapes' dimensions appended. For both this Shape and the
+   * other Shape, {@link Shape#isUnknown()} must return false. E.g. @code
+   * Shape.of(3,4).append(Shape.of(1,2)) =&gt; Shape.of(3,4,1,2) }
    *
    * @param other another Shape, must not be {@code null}, must not be unknown
-   * @return A new Shape consisting of this Shape's dimensions followed by the given Shape's dimensions
+   * @return A new Shape consisting of this Shape's dimensions followed by the given Shape's
+   *     dimensions
    */
   public Shape append(Shape other) {
     long[] newDimensions = new long[dimensionSizes.length + other.dimensionSizes.length];
@@ -408,8 +412,8 @@ public final class Shape {
    * <p>
    *
    * <p>Two possibly-partially-defined shapes are compatible if there exists a fully-defined shape
-   * that both shapes can represent. Thus, compatibility allows the shape inference code to reason about
-   * partially-defined shapes. For example:
+   * that both shapes can represent. Thus, compatibility allows the shape inference code to reason
+   * about partially-defined shapes. For example:
    *
    * <ul>
    *   <li><code>Shape.unknown()</code> is compatible with all shapes.

--- a/ndarray/src/main/java/org/tensorflow/ndarray/Shape.java
+++ b/ndarray/src/main/java/org/tensorflow/ndarray/Shape.java
@@ -77,8 +77,8 @@ public final class Shape {
    * Shape scalar = Shape.of()
    * }</pre>
    *
-   * @param dimensionSizes number of elements in each dimension of this shape, if any, or {@link Shape#UNKNOWN_SIZE} if
-   * unknown.
+   * @param dimensionSizes number of elements in each dimension of this shape, if any, or
+   *                       {@link Shape#UNKNOWN_SIZE} if unknown.
    * @return a new shape
    */
   public static Shape of(long... dimensionSizes) {

--- a/ndarray/src/main/java/org/tensorflow/ndarray/Shape.java
+++ b/ndarray/src/main/java/org/tensorflow/ndarray/Shape.java
@@ -17,18 +17,22 @@ limitations under the License.
 
 package org.tensorflow.ndarray;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 /**
  * The shape of a Tensor or {@link NdArray}.
  *
  * <p>A {@code Shape} defines sizes along its axes. It may contain an unknown size for one of the
- * axes or may be totally unknown, in which case not even the number of axes is known. If the size
- * of an axis is unknown, {@link Shape#UNKNOWN_SIZE} should be used as its size.
+ * axes or may be totally unknown, in which case not even the number of axes is known. If the size of an axis is
+ * unknown, {@link Shape#UNKNOWN_SIZE} should be used as its size.
  */
 public final class Shape {
 
-  /** The size of an unknown axis or the total unknown size for an unknown Shape. */
+  /**
+   * The size of an unknown axis or the total unknown size for an unknown Shape.
+   */
   public static long UNKNOWN_SIZE = -1L;
 
   /**
@@ -53,9 +57,8 @@ public final class Shape {
    * Create a Shape representing a scalar or an N-dimensional value.
    *
    * <p>Creates a Shape representing a scalar or an N-dimensional value (N being at least 1), with
-   * the provided size for each dimension. A -1 indicates that the size of the corresponding
-   * dimension is unknown. If no sizes are provided, a Shape representing a scalar is created. For
-   * example:
+   * the provided size for each dimension. A -1 indicates that the size of the corresponding dimension is unknown. If no
+   * sizes are provided, a Shape representing a scalar is created. For example:
    *
    * <pre>{@code
    * // A 2-element vector.
@@ -74,8 +77,8 @@ public final class Shape {
    * Shape scalar = Shape.of()
    * }</pre>
    *
-   * @param dimensionSizes number of elements in each dimension of this shape, if any, or
-   *                       {@link Shape#UNKNOWN_SIZE} if unknown.
+   * @param dimensionSizes number of elements in each dimension of this shape, if any, or {@link Shape#UNKNOWN_SIZE} if
+   * unknown.
    * @return a new shape
    */
   public static Shape of(long... dimensionSizes) {
@@ -91,8 +94,8 @@ public final class Shape {
    * <p>If {@link Shape#isUnknown()} is true or {@link Shape#hasUnknownDimension()} is true, {@link
    * Shape#UNKNOWN_SIZE} is returned.
    *
-   * @return The total number of elements a Tensor with this shape would have if it can be
-   *     calculated, else {@link Shape#UNKNOWN_SIZE}.
+   * @return The total number of elements a Tensor with this shape would have if it can be calculated, else {@link
+   * Shape#UNKNOWN_SIZE}.
    */
   public long size() {
     if (size == null) {
@@ -107,14 +110,13 @@ public final class Shape {
    * <p>If {@link Shape#isUnknown()} is true or the size of the dimension with the given index has
    * an unknown size, {@link Shape#UNKNOWN_SIZE} is returned.
    *
-   * @param i the index of the dimension to get the size for. If this Shape has a known number of
-   *     dimensions, it must be &lt; {@link Shape#numDimensions()}. The index may be negative, in which
-   *     case the position is counted from the end of the shape. E.g.: {@code size(-1)} returns the
-   *     size of the last dimension, {@code size(-2)} the size of the second to last dimension etc.
-   * @return The size of the dimension with the given index if known, {@link Shape#UNKNOWN_SIZE}
-   *     otherwise.
+   * @param i the index of the dimension to get the size for. If this Shape has a known number of dimensions, it must be
+   * &lt; {@link Shape#numDimensions()}. The index may be negative, in which case the position is counted from the end
+   * of the shape. E.g.: {@code size(-1)} returns the size of the last dimension, {@code size(-2)} the size of the
+   * second to last dimension etc.
+   * @return The size of the dimension with the given index if known, {@link Shape#UNKNOWN_SIZE} otherwise.
    */
-  public long size(int i) {
+  public long get(int i) {
     if (dimensionSizes == null) {
       return UNKNOWN_SIZE;
     } else if (i >= 0) {
@@ -125,14 +127,15 @@ public final class Shape {
   }
 
   /**
-   * Returns the number of dimensions of this Shape. -1 if unknown, 0 for a scalar, 1 for a vector,
-   * 2 for a matrix etc.
+   * Returns the number of dimensions of this Shape. -1 if unknown, 0 for a scalar, 1 for a vector, 2 for a matrix etc.
    */
   public int numDimensions() {
     return dimensionSizes != null ? dimensionSizes.length : -1;
   }
 
-  /** Returns whether one or more dimensions of this Shape have an unknown size. */
+  /**
+   * Returns whether one or more dimensions of this Shape have an unknown size.
+   */
   public boolean hasUnknownDimension() {
     if (dimensionSizes == null) {
       return true;
@@ -145,29 +148,37 @@ public final class Shape {
     return false;
   }
 
-  /** Returns whether this Shape represents a scalar. */
+  /**
+   * Returns whether this Shape represents a scalar.
+   */
   public boolean isScalar() {
     return dimensionSizes != null && dimensionSizes.length == 0;
   }
 
-  /** Returns whether this Shape is the shape of a vector. */
+  /**
+   * Returns whether this Shape is the shape of a vector.
+   */
   public boolean isVector() {
     return dimensionSizes != null && dimensionSizes.length == 1;
   }
 
-  /** Returns whether this Shape is the shape of a matrix */
+  /**
+   * Returns whether this Shape is the shape of a matrix
+   */
   public boolean isMatrix() {
     return dimensionSizes != null && dimensionSizes.length == 2;
   }
 
-  /** Returns whether the number of dimensions of this Shape is unknown. */
+  /**
+   * Returns whether the number of dimensions of this Shape is unknown.
+   */
   public boolean isUnknown() {
     return dimensionSizes == null;
   }
 
   /**
-   * Returns a defensive copy of the this Shape's axes. Changes to the returned array to not change
-   * this Shape's state. Returns null if {@link Shape#isUnknown()} is true.
+   * Returns a defensive copy of the this Shape's axes. Changes to the returned array to not change this Shape's state.
+   * Returns null if {@link Shape#isUnknown()} is true.
    */
   public long[] asArray() {
     if (this.dimensionSizes == null) {
@@ -175,6 +186,24 @@ public final class Shape {
     } else {
       return Arrays.copyOf(dimensionSizes, dimensionSizes.length);
     }
+  }
+
+  /**
+   * Returns a defensive copy of the this Shape's axes. Changes to the returned list do not change this Shape's state.
+   * Returns null if {@link Shape#isUnknown()} is true.
+   */
+  public List<Long> toListOrNull() {
+    long[] array = asArray();
+    if (array == null) {
+      return null;
+    }
+
+    List<Long> list = new ArrayList<>(array.length);
+    for (long l : array) {
+      list.add(l);
+    }
+
+    return list;
   }
 
   @Override
@@ -212,7 +241,9 @@ public final class Shape {
     return false;
   }
 
-  /** Succinct description of the Shape meant for debugging. */
+  /**
+   * Succinct description of the Shape meant for debugging.
+   */
   @Override
   public String toString() {
     return Arrays.toString(dimensionSizes);
@@ -233,12 +264,10 @@ public final class Shape {
   }
 
   /**
-   * Returns an n-dimensional Shape with the dimensions matching the first n dimensions of this
-   * shape
+   * Returns an n-dimensional Shape with the dimensions matching the first n dimensions of this shape
    *
    * @param n the number of leading dimensions to get, must be &lt;= than {@link Shape#numDimensions()}
-   * @return an n-dimensional Shape with the first n dimensions matching the first n dimensions of
-   *     this Shape
+   * @return an n-dimensional Shape with the first n dimensions matching the first n dimensions of this Shape
    */
   public Shape take(int n) {
     if (n > numDimensions()) {
@@ -250,20 +279,21 @@ public final class Shape {
     return Shape.of(newDimensions);
   }
 
-  /** Returns a new Shape, with this Shape's first dimension removed. */
+  /**
+   * Returns a new Shape, with this Shape's first dimension removed.
+   */
   public Shape tail() {
-    if (dimensionSizes.length < 2) return Shape.of();
+    if (dimensionSizes.length < 2) {
+      return Shape.of();
+    }
     return Shape.of(Arrays.copyOfRange(dimensionSizes, 1, dimensionSizes.length));
   }
 
   /**
-   * Returns an n-dimensional Shape with the dimensions matching the last n dimensions of this
-   * Shape.
+   * Returns an n-dimensional Shape with the dimensions matching the last n dimensions of this Shape.
    *
-   * @param n the number of trailing dimensions to get, must be &lt;= than {@link
-   *     Shape#numDimensions()}
-   * @return an n-dimensional shape with the dimensions matching the last n dimensions of this
-   *     Shape, never null
+   * @param n the number of trailing dimensions to get, must be &lt;= than {@link Shape#numDimensions()}
+   * @return an n-dimensional shape with the dimensions matching the last n dimensions of this Shape, never null
    */
   public Shape takeLast(int n) {
     if (n > numDimensions()) {
@@ -276,12 +306,14 @@ public final class Shape {
   }
 
   /**
-   * Return a {@code end - begin} dimensional shape with dimensions matching this Shape from {@code begin} to {@code end}.
+   * Return a {@code end - begin} dimensional shape with dimensions matching this Shape from {@code begin} to {@code
+   * end}.
+   *
    * @param begin Where to start the sub-shape.
    * @param end Where to end the sub-shape, exclusive.
    * @return the sub-shape bounded by begin and end.
    */
-  public Shape subShape(int begin, int end){
+  public Shape subShape(int begin, int end) {
     if (end > numDimensions()) {
       throw new ArrayIndexOutOfBoundsException(
           "End index " + end + " out of bounds: shape only has " + numDimensions() + " dimensions.");
@@ -297,12 +329,11 @@ public final class Shape {
   }
 
   /**
-   * Returns a new Shape, with a new first dimension added. In order for this call to succeed,
-   * {@link Shape#isUnknown()} must be {@code false}.
+   * Returns a new Shape, with a new first dimension added. In order for this call to succeed, {@link Shape#isUnknown()}
+   * must be {@code false}.
    *
    * @param firstDimension the dimension to prepend
-   * @return a new shape with the given dimension first, followed by this Shape's dimensions, never
-   *     null
+   * @return a new shape with the given dimension first, followed by this Shape's dimensions, never null
    */
   public Shape prepend(long firstDimension) {
     long[] newDimensions = new long[dimensionSizes.length + 1];
@@ -313,8 +344,8 @@ public final class Shape {
   }
 
   /**
-   * Returns a new Shape, with a new last dimension added. In order for this call to succeed, {@link
-   * Shape#isUnknown()} must be {@code false}.
+   * Returns a new Shape, with a new last dimension added. In order for this call to succeed, {@link Shape#isUnknown()}
+   * must be {@code false}.
    *
    * @param lastDimension the dimension to append
    * @return a new Shape with this Shape's dimensions followed by the given dimension, never null
@@ -328,13 +359,11 @@ public final class Shape {
   }
 
   /**
-   * Returns a new Shape, with another Shape's dimensions prepended. For both this Shape and the
-   * other Shape, {@link Shape#isUnknown()} must return false. E.g. {@code
-   * Shape.of(3,4).prepend(Shape.of(1,2)) => Shape.of(1,2,3,4) }
+   * Returns a new Shape, with another Shape's dimensions prepended. For both this Shape and the other Shape, {@link
+   * Shape#isUnknown()} must return false. E.g. {@code Shape.of(3,4).prepend(Shape.of(1,2)) => Shape.of(1,2,3,4) }
    *
    * @param other another Shape, must not be {@code null}, must not be unknown
-   * @return A new Shape consisting of the given Shape's dimensions followed by this Shape's
-   *     dimensions, never null
+   * @return A new Shape consisting of the given Shape's dimensions followed by this Shape's dimensions, never null
    */
   public Shape prepend(Shape other) {
     long[] newDimensions = new long[other.dimensionSizes.length + dimensionSizes.length];
@@ -345,13 +374,11 @@ public final class Shape {
   }
 
   /**
-   * Returns a new Shape, with another Shapes' dimensions appended. For both this Shape and the
-   * other Shape, {@link Shape#isUnknown()} must return false. E.g. @code
-   * Shape.of(3,4).append(Shape.of(1,2)) =&gt; Shape.of(3,4,1,2) }
+   * Returns a new Shape, with another Shapes' dimensions appended. For both this Shape and the other Shape, {@link
+   * Shape#isUnknown()} must return false. E.g. @code Shape.of(3,4).append(Shape.of(1,2)) =&gt; Shape.of(3,4,1,2) }
    *
    * @param other another Shape, must not be {@code null}, must not be unknown
-   * @return A new Shape consisting of this Shape's dimensions followed by the given Shape's
-   *     dimensions
+   * @return A new Shape consisting of this Shape's dimensions followed by the given Shape's dimensions
    */
   public Shape append(Shape other) {
     long[] newDimensions = new long[dimensionSizes.length + other.dimensionSizes.length];
@@ -381,8 +408,8 @@ public final class Shape {
    * <p>
    *
    * <p>Two possibly-partially-defined shapes are compatible if there exists a fully-defined shape
-   * that both shapes can represent. Thus, compatibility allows the shape inference code to reason
-   * about partially-defined shapes. For example:
+   * that both shapes can represent. Thus, compatibility allows the shape inference code to reason about
+   * partially-defined shapes. For example:
    *
    * <ul>
    *   <li><code>Shape.unknown()</code> is compatible with all shapes.
@@ -423,7 +450,7 @@ public final class Shape {
         return false;
       }
       for (int i = 0; i < numDimensions(); i++) {
-        if (!isCompatible(size(i), shape.size(i))) {
+        if (!isCompatible(get(i), shape.get(i))) {
           return false;
         }
       }

--- a/ndarray/src/main/java/org/tensorflow/ndarray/Shape.java
+++ b/ndarray/src/main/java/org/tensorflow/ndarray/Shape.java
@@ -116,6 +116,26 @@ public final class Shape {
    *     dimension etc.
    * @return The size of the dimension with the given index if known, {@link Shape#UNKNOWN_SIZE}
    *     otherwise.
+   * @deprecated Renamed to {@link #get(int)}.
+   */
+  @Deprecated
+  public long size(int i){
+    return get(i);
+  }
+
+  /**
+   * The size of the dimension with the given index.
+   *
+   * <p>If {@link Shape#isUnknown()} is true or the size of the dimension with the given index has
+   * an unknown size, {@link Shape#UNKNOWN_SIZE} is returned.
+   *
+   * @param i the index of the dimension to get the size for. If this Shape has a known number of
+   *     dimensions, it must be &lt; {@link Shape#numDimensions()}. The index may be negative, in
+   *     which case the position is counted from the end of the shape. E.g.: {@code size(-1)}
+   *     returns the size of the last dimension, {@code size(-2)} the size of the second to last
+   *     dimension etc.
+   * @return The size of the dimension with the given index if known, {@link Shape#UNKNOWN_SIZE}
+   *     otherwise.
    */
   public long get(int i) {
     if (dimensionSizes == null) {

--- a/ndarray/src/main/java/org/tensorflow/ndarray/StdArrays.java
+++ b/ndarray/src/main/java/org/tensorflow/ndarray/StdArrays.java
@@ -1,5 +1,7 @@
 package org.tensorflow.ndarray;
 
+import static org.tensorflow.ndarray.NdArrays.vectorOf;
+
 import java.lang.reflect.Array;
 import org.tensorflow.ndarray.buffer.DataBuffers;
 
@@ -535,7 +537,7 @@ public final class StdArrays {
    */
   public static <T> NdArray<T> ndCopyOf(T[][] array) {
     @SuppressWarnings("unchecked")
-    NdArray<T> ndArray = NdArrays.ofObjects(componentTypeOf(array), shapeOf(array));
+    NdArray<T>ndArray = NdArrays.ofObjects(componentTypeOf(array), shapeOf(array));
     copyTo(array, ndArray);
     return ndArray;
   }
@@ -549,7 +551,7 @@ public final class StdArrays {
    */
   public static <T> NdArray<T> ndCopyOf(T[][][] array) {
     @SuppressWarnings("unchecked")
-    NdArray<T> ndArray = NdArrays.ofObjects(componentTypeOf(array), shapeOf(array));
+    NdArray<T>ndArray = NdArrays.ofObjects(componentTypeOf(array), shapeOf(array));
     copyTo(array, ndArray);
     return ndArray;
   }
@@ -563,7 +565,7 @@ public final class StdArrays {
    */
   public static <T> NdArray<T> ndCopyOf(T[][][][] array) {
     @SuppressWarnings("unchecked")
-    NdArray<T> ndArray = NdArrays.ofObjects(componentTypeOf(array), shapeOf(array));
+    NdArray<T>ndArray = NdArrays.ofObjects(componentTypeOf(array), shapeOf(array));
     copyTo(array, ndArray);
     return ndArray;
   }
@@ -577,7 +579,7 @@ public final class StdArrays {
    */
   public static <T> NdArray<T> ndCopyOf(T[][][][][] array) {
     @SuppressWarnings("unchecked")
-    NdArray<T> ndArray = NdArrays.ofObjects(componentTypeOf(array), shapeOf(array));
+    NdArray<T>ndArray = NdArrays.ofObjects(componentTypeOf(array), shapeOf(array));
     copyTo(array, ndArray);
     return ndArray;
   }
@@ -591,7 +593,7 @@ public final class StdArrays {
    */
   public static <T> NdArray<T> ndCopyOf(T[][][][][][] array) {
     @SuppressWarnings("unchecked")
-    NdArray<T> ndArray = NdArrays.ofObjects(componentTypeOf(array), shapeOf(array));
+    NdArray<T>ndArray = NdArrays.ofObjects(componentTypeOf(array), shapeOf(array));
     copyTo(array, ndArray);
     return ndArray;
   }
@@ -601,8 +603,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-1 or has a shape that exceeds standard arrays
-   * limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-1 or has a shape that
+   *                                  exceeds standard arrays limits
    */
   public static int[] array1dCopyOf(IntNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 1);
@@ -616,8 +618,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-2 or has a shape that exceeds standard arrays
-   * limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-2 or has a shape that
+   *                                  exceeds standard arrays limits
    */
   public static int[][] array2dCopyOf(IntNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 2);
@@ -631,8 +633,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-3 or has a shape that exceeds standard arrays
-   * limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-3 or has a shape that
+   *                                  exceeds standard arrays limits
    */
   public static int[][][] array3dCopyOf(IntNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 3);
@@ -646,8 +648,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-4 or has a shape that exceeds standard arrays
-   * limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-4 or has a shape that
+   *                                  exceeds standard arrays limits
    */
   public static int[][][][] array4dCopyOf(IntNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 4);
@@ -661,8 +663,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-5 or has a shape that exceeds standard arrays
-   * limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-5 or has a shape that
+   *                                  exceeds standard arrays limits
    */
   public static int[][][][][] array5dCopyOf(IntNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 5);
@@ -676,8 +678,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-6 or has a shape that exceeds standard arrays
-   * limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-6 or has a shape that
+   *                                  exceeds standard arrays limits
    */
   public static int[][][][][][] array6dCopyOf(IntNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 6);
@@ -691,8 +693,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-1 or has a shape that exceeds standard arrays
-   * limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-1 or has a shape that
+   *                                  exceeds standard arrays limits
    */
   public static long[] array1dCopyOf(LongNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 1);
@@ -706,8 +708,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-2 or has a shape that exceeds standard arrays
-   * limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-2 or has a shape that
+   *                                  exceeds standard arrays limits
    */
   public static long[][] array2dCopyOf(LongNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 2);
@@ -721,8 +723,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-3 or has a shape that exceeds standard arrays
-   * limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-3 or has a shape that
+   *                                  exceeds standard arrays limits
    */
   public static long[][][] array3dCopyOf(LongNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 3);
@@ -736,8 +738,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-4 or has a shape that exceeds standard arrays
-   * limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-4 or has a shape that
+   *                                  exceeds standard arrays limits
    */
   public static long[][][][] array4dCopyOf(LongNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 4);
@@ -751,8 +753,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-5 or has a shape that exceeds standard arrays
-   * limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-5 or has a shape that
+   *                                  exceeds standard arrays limits
    */
   public static long[][][][][] array5dCopyOf(LongNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 5);
@@ -766,8 +768,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-6 or has a shape that exceeds standard arrays
-   * limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-6 or has a shape that
+   *                                  exceeds standard arrays limits
    */
   public static long[][][][][][] array6dCopyOf(LongNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 6);
@@ -781,8 +783,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-1 or has a shape that exceeds standard arrays
-   * limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-1 or has a shape that
+   *                                  exceeds standard arrays limits
    */
   public static float[] array1dCopyOf(FloatNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 1);
@@ -796,8 +798,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-2 or has a shape that exceeds standard arrays
-   * limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-2 or has a shape that
+   *                                  exceeds standard arrays limits
    */
   public static float[][] array2dCopyOf(FloatNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 2);
@@ -811,8 +813,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-3 or has a shape that exceeds standard arrays
-   * limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-3 or has a shape that
+   *                                  exceeds standard arrays limits
    */
   public static float[][][] array3dCopyOf(FloatNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 3);
@@ -826,8 +828,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-4 or has a shape that exceeds standard arrays
-   * limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-4 or has a shape that
+   *                                  exceeds standard arrays limits
    */
   public static float[][][][] array4dCopyOf(FloatNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 4);
@@ -841,8 +843,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-5 or has a shape that exceeds standard arrays
-   * limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-5 or has a shape that
+   *                                  exceeds standard arrays limits
    */
   public static float[][][][][] array5dCopyOf(FloatNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 5);
@@ -856,8 +858,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-6 or has a shape that exceeds standard arrays
-   * limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-6 or has a shape that
+   *                                  exceeds standard arrays limits
    */
   public static float[][][][][][] array6dCopyOf(FloatNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 6);
@@ -871,8 +873,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-1 or has a shape that exceeds standard arrays
-   * limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-1 or has a shape that
+   *                                  exceeds standard arrays limits
    */
   public static double[] array1dCopyOf(DoubleNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 1);
@@ -886,8 +888,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-2 or has a shape that exceeds standard arrays
-   * limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-2 or has a shape that
+   *                                  exceeds standard arrays limits
    */
   public static double[][] array2dCopyOf(DoubleNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 2);
@@ -901,8 +903,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-3 or has a shape that exceeds standard arrays
-   * limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-3 or has a shape that
+   *                                  exceeds standard arrays limits
    */
   public static double[][][] array3dCopyOf(DoubleNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 3);
@@ -916,8 +918,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-4 or has a shape that exceeds standard arrays
-   * limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-4 or has a shape that
+   *                                  exceeds standard arrays limits
    */
   public static double[][][][] array4dCopyOf(DoubleNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 4);
@@ -931,8 +933,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-5 or has a shape that exceeds standard arrays
-   * limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-5 or has a shape that
+   *                                  exceeds standard arrays limits
    */
   public static double[][][][][] array5dCopyOf(DoubleNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 5);
@@ -946,8 +948,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-6 or has a shape that exceeds standard arrays
-   * limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-6 or has a shape that
+   *                                  exceeds standard arrays limits
    */
   public static double[][][][][][] array6dCopyOf(DoubleNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 6);
@@ -961,8 +963,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-1 or has a shape that exceeds standard arrays
-   * limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-1 or has a shape that
+   *                                  exceeds standard arrays limits
    */
   public static byte[] array1dCopyOf(ByteNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 1);
@@ -976,8 +978,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-2 or has a shape that exceeds standard arrays
-   * limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-2 or has a shape that
+   *                                  exceeds standard arrays limits
    */
   public static byte[][] array2dCopyOf(ByteNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 2);
@@ -991,8 +993,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-3 or has a shape that exceeds standard arrays
-   * limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-3 or has a shape that
+   *                                  exceeds standard arrays limits
    */
   public static byte[][][] array3dCopyOf(ByteNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 3);
@@ -1006,8 +1008,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-4 or has a shape that exceeds standard arrays
-   * limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-4 or has a shape that
+   *                                  exceeds standard arrays limits
    */
   public static byte[][][][] array4dCopyOf(ByteNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 4);
@@ -1021,8 +1023,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-5 or has a shape that exceeds standard arrays
-   * limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-5 or has a shape that
+   *                                  exceeds standard arrays limits
    */
   public static byte[][][][][] array5dCopyOf(ByteNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 5);
@@ -1036,8 +1038,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-6 or has a shape that exceeds standard arrays
-   * limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-6 or has a shape that
+   *                                  exceeds standard arrays limits
    */
   public static byte[][][][][][] array6dCopyOf(ByteNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 6);
@@ -1051,8 +1053,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-1 or has a shape that exceeds standard arrays
-   * limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-1 or has a shape that
+   *                                  exceeds standard arrays limits
    */
   public static short[] array1dCopyOf(ShortNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 1);
@@ -1066,8 +1068,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-2 or has a shape that exceeds standard arrays
-   * limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-2 or has a shape that
+   *                                  exceeds standard arrays limits
    */
   public static short[][] array2dCopyOf(ShortNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 2);
@@ -1081,8 +1083,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-3 or has a shape that exceeds standard arrays
-   * limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-3 or has a shape that
+   *                                  exceeds standard arrays limits
    */
   public static short[][][] array3dCopyOf(ShortNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 3);
@@ -1096,8 +1098,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-4 or has a shape that exceeds standard arrays
-   * limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-4 or has a shape that
+   *                                  exceeds standard arrays limits
    */
   public static short[][][][] array4dCopyOf(ShortNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 4);
@@ -1111,8 +1113,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-5 or has a shape that exceeds standard arrays
-   * limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-5 or has a shape that
+   *                                  exceeds standard arrays limits
    */
   public static short[][][][][] array5dCopyOf(ShortNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 5);
@@ -1126,8 +1128,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-6 or has a shape that exceeds standard arrays
-   * limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-6 or has a shape that
+   *                                  exceeds standard arrays limits
    */
   public static short[][][][][][] array6dCopyOf(ShortNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 6);
@@ -1141,8 +1143,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-1 or has a shape that exceeds standard arrays
-   * limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-1 or has a shape that
+   *                                  exceeds standard arrays limits
    */
   public static boolean[] array1dCopyOf(BooleanNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 1);
@@ -1156,8 +1158,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-2 or has a shape that exceeds standard arrays
-   * limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-2 or has a shape that
+   *                                  exceeds standard arrays limits
    */
   public static boolean[][] array2dCopyOf(BooleanNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 2);
@@ -1171,8 +1173,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-3 or has a shape that exceeds standard arrays
-   * limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-3 or has a shape that
+   *                                  exceeds standard arrays limits
    */
   public static boolean[][][] array3dCopyOf(BooleanNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 3);
@@ -1186,8 +1188,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-4 or has a shape that exceeds standard arrays
-   * limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-4 or has a shape that
+   *                                  exceeds standard arrays limits
    */
   public static boolean[][][][] array4dCopyOf(BooleanNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 4);
@@ -1201,8 +1203,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-5 or has a shape that exceeds standard arrays
-   * limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-5 or has a shape that
+   *                                  exceeds standard arrays limits
    */
   public static boolean[][][][][] array5dCopyOf(BooleanNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 5);
@@ -1216,8 +1218,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-6 or has a shape that exceeds standard arrays
-   * limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-6 or has a shape that
+   *                                  exceeds standard arrays limits
    */
   public static boolean[][][][][][] array6dCopyOf(BooleanNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 6);
@@ -1233,12 +1235,12 @@ public final class StdArrays {
    * @param objectType type of object
    * @param <T> data type
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-1 or has a shape that exceeds standard arrays
-   * limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-1 or has a shape that
+   *                                  exceeds standard arrays limits
    */
   public static <T> T[] array1dCopyOf(NdArray<T> ndArray, Class<T> objectType) {
     int[] dims = computeArrayDims(ndArray, 1);
-    T[] array = (T[]) Array.newInstance(objectType, dims[0]);
+    T[] array = (T[])Array.newInstance(objectType, dims[0]);
     copyFrom(ndArray, array);
     return array;
   }
@@ -1250,12 +1252,12 @@ public final class StdArrays {
    * @param objectType type of object
    * @param <T> data type
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-2 or has a shape that exceeds standard arrays
-   * limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-2 or has a shape that
+   *                                  exceeds standard arrays limits
    */
   public static <T> T[][] array2dCopyOf(NdArray<T> ndArray, Class<T> objectType) {
     int[] dims = computeArrayDims(ndArray, 2);
-    T[][] array = (T[][]) Array.newInstance(objectType, dims[0], dims[1]);
+    T[][] array = (T[][])Array.newInstance(objectType, dims[0], dims[1]);
     copyFrom(ndArray, array);
     return array;
   }
@@ -1267,12 +1269,12 @@ public final class StdArrays {
    * @param objectType type of object
    * @param <T> data type
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-3 or has a shape that exceeds standard arrays
-   * limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-3 or has a shape that
+   *                                  exceeds standard arrays limits
    */
   public static <T> T[][][] array3dCopyOf(NdArray<T> ndArray, Class<T> objectType) {
     int[] dims = computeArrayDims(ndArray, 3);
-    T[][][] array = (T[][][]) Array.newInstance(objectType, dims[0], dims[1], dims[2]);
+    T[][][] array = (T[][][])Array.newInstance(objectType, dims[0], dims[1], dims[2]);
     copyFrom(ndArray, array);
     return array;
   }
@@ -1284,12 +1286,12 @@ public final class StdArrays {
    * @param objectType type of object
    * @param <T> data type
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-4 or has a shape that exceeds standard arrays
-   * limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-4 or has a shape that
+   *                                  exceeds standard arrays limits
    */
   public static <T> T[][][][] array4dCopyOf(NdArray<T> ndArray, Class<T> objectType) {
     int[] dims = computeArrayDims(ndArray, 4);
-    T[][][][] array = (T[][][][]) Array.newInstance(objectType, dims[0], dims[1], dims[2], dims[3]);
+    T[][][][] array = (T[][][][])Array.newInstance(objectType, dims[0], dims[1], dims[2], dims[3]);
     copyFrom(ndArray, array);
     return array;
   }
@@ -1301,13 +1303,13 @@ public final class StdArrays {
    * @param objectType type of object
    * @param <T> data type
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-5 or has a shape that exceeds standard arrays
-   * limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-5 or has a shape that
+   *                                  exceeds standard arrays limits
    */
   public static <T> T[][][][][] array5dCopyOf(NdArray<T> ndArray, Class<T> objectType) {
     int[] dims = computeArrayDims(ndArray, 5);
     T[][][][][] array =
-        (T[][][][][]) Array.newInstance(objectType, dims[0], dims[1], dims[2], dims[3], dims[4]);
+        (T[][][][][])Array.newInstance(objectType, dims[0], dims[1], dims[2], dims[3], dims[4]);
     copyFrom(ndArray, array);
     return array;
   }
@@ -1319,13 +1321,13 @@ public final class StdArrays {
    * @param objectType type of object
    * @param <T> data type
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-6 or has a shape that exceeds standard arrays
-   * limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-6 or has a shape that
+   *                                  exceeds standard arrays limits
    */
   public static <T> T[][][][][][] array6dCopyOf(NdArray<T> ndArray, Class<T> objectType) {
     int[] dims = computeArrayDims(ndArray, 6);
     T[][][][][][] array =
-        (T[][][][][][]) Array.newInstance(objectType, dims[0], dims[1], dims[2], dims[3], dims[4], dims[5]);
+        (T[][][][][][])Array.newInstance(objectType, dims[0], dims[1], dims[2], dims[3], dims[4], dims[5]);
     copyFrom(ndArray, array);
     return array;
   }
@@ -1335,8 +1337,8 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-1 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-1 or has an incompatible shape with the source
-   * array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-1 or has an incompatible shape
+   *                                  with the source array
    */
   public static void copyTo(int[] src, IntNdArray dst) {
     NdArrays.vectorOf(src).copyTo(dst);
@@ -1347,12 +1349,12 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-2 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-2 or has an incompatible shape with the source
-   * array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-2 or has an incompatible shape
+   *                                  with the source array
    */
   public static void copyTo(int[][] src, IntNdArray dst) {
     dst.elements(0).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(src[(int) idx[0]]).copyTo(e)
+        NdArrays.vectorOf(src[(int)idx[0]]).copyTo(e)
     );
   }
 
@@ -1361,12 +1363,12 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-3 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-3 or has an incompatible shape with the source
-   * array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-3 or has an incompatible shape
+   *                                  with the source array
    */
   public static void copyTo(int[][][] src, IntNdArray dst) {
     dst.elements(1).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(src[(int) idx[0]][(int) idx[1]]).copyTo(e)
+        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]]).copyTo(e)
     );
   }
 
@@ -1375,12 +1377,12 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-4 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-4 or has an incompatible shape with the source
-   * array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-4 or has an incompatible shape
+   *                                  with the source array
    */
   public static void copyTo(int[][][][] src, IntNdArray dst) {
     dst.elements(2).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(src[(int) idx[0]][(int) idx[1]][(int) idx[2]]).copyTo(e)
+        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]][(int)idx[2]]).copyTo(e)
     );
   }
 
@@ -1389,12 +1391,12 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-5 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-5 or has an incompatible shape with the source
-   * array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-5 or has an incompatible shape
+   *                                  with the source array
    */
   public static void copyTo(int[][][][][] src, IntNdArray dst) {
     dst.elements(3).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(src[(int) idx[0]][(int) idx[1]][(int) idx[2]][(int) idx[3]]).copyTo(e)
+        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]]).copyTo(e)
     );
   }
 
@@ -1403,12 +1405,12 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-6 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-6 or has an incompatible shape with the source
-   * array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-6 or has an incompatible shape
+   *                                  with the source array
    */
   public static void copyTo(int[][][][][][] src, IntNdArray dst) {
     dst.elements(4).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(src[(int) idx[0]][(int) idx[1]][(int) idx[2]][(int) idx[3]][(int) idx[4]]).copyTo(e)
+        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]][(int)idx[4]]).copyTo(e)
     );
   }
 
@@ -1417,8 +1419,8 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-1 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-1 or has an incompatible shape with the source
-   * array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-1 or has an incompatible shape
+   *                                  with the source array
    */
   public static void copyTo(long[] src, LongNdArray dst) {
     NdArrays.vectorOf(src).copyTo(dst);
@@ -1429,12 +1431,12 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-2 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-2 or has an incompatible shape with the source
-   * array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-2 or has an incompatible shape
+   *                                  with the source array
    */
   public static void copyTo(long[][] src, LongNdArray dst) {
     dst.elements(0).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(src[(int) idx[0]]).copyTo(e)
+        NdArrays.vectorOf(src[(int)idx[0]]).copyTo(e)
     );
   }
 
@@ -1443,12 +1445,12 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-3 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-3 or has an incompatible shape with the source
-   * array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-3 or has an incompatible shape
+   *                                  with the source array
    */
   public static void copyTo(long[][][] src, LongNdArray dst) {
     dst.elements(1).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(src[(int) idx[0]][(int) idx[1]]).copyTo(e)
+        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]]).copyTo(e)
     );
   }
 
@@ -1457,12 +1459,12 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-4 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-4 or has an incompatible shape with the source
-   * array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-4 or has an incompatible shape
+   *                                  with the source array
    */
   public static void copyTo(long[][][][] src, LongNdArray dst) {
     dst.elements(2).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(src[(int) idx[0]][(int) idx[1]][(int) idx[2]]).copyTo(e)
+        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]][(int)idx[2]]).copyTo(e)
     );
   }
 
@@ -1471,12 +1473,12 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-5 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-5 or has an incompatible shape with the source
-   * array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-5 or has an incompatible shape
+   *                                  with the source array
    */
   public static void copyTo(long[][][][][] src, LongNdArray dst) {
     dst.elements(3).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(src[(int) idx[0]][(int) idx[1]][(int) idx[2]][(int) idx[3]]).copyTo(e)
+        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]]).copyTo(e)
     );
   }
 
@@ -1485,12 +1487,12 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-6 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-6 or has an incompatible shape with the source
-   * array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-6 or has an incompatible shape
+   *                                  with the source array
    */
   public static void copyTo(long[][][][][][] src, LongNdArray dst) {
     dst.elements(4).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(src[(int) idx[0]][(int) idx[1]][(int) idx[2]][(int) idx[3]][(int) idx[4]]).copyTo(e)
+        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]][(int)idx[4]]).copyTo(e)
     );
   }
 
@@ -1499,8 +1501,8 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-1 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-1 or has an incompatible shape with the source
-   * array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-1 or has an incompatible shape
+   *                                  with the source array
    */
   public static void copyTo(float[] src, FloatNdArray dst) {
     NdArrays.vectorOf(src).copyTo(dst);
@@ -1511,12 +1513,12 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-2 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-2 or has an incompatible shape with the source
-   * array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-2 or has an incompatible shape
+   *                                  with the source array
    */
   public static void copyTo(float[][] src, FloatNdArray dst) {
     dst.elements(0).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(src[(int) idx[0]]).copyTo(e)
+        NdArrays.vectorOf(src[(int)idx[0]]).copyTo(e)
     );
   }
 
@@ -1525,12 +1527,12 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-3 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-3 or has an incompatible shape with the source
-   * array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-3 or has an incompatible shape
+   *                                  with the source array
    */
   public static void copyTo(float[][][] src, FloatNdArray dst) {
     dst.elements(1).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(src[(int) idx[0]][(int) idx[1]]).copyTo(e)
+        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]]).copyTo(e)
     );
   }
 
@@ -1539,12 +1541,12 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-4 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-4 or has an incompatible shape with the source
-   * array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-4 or has an incompatible shape
+   *                                  with the source array
    */
   public static void copyTo(float[][][][] src, FloatNdArray dst) {
     dst.elements(2).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(src[(int) idx[0]][(int) idx[1]][(int) idx[2]]).copyTo(e)
+        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]][(int)idx[2]]).copyTo(e)
     );
   }
 
@@ -1553,12 +1555,12 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-5 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-5 or has an incompatible shape with the source
-   * array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-5 or has an incompatible shape
+   *                                  with the source array
    */
   public static void copyTo(float[][][][][] src, FloatNdArray dst) {
     dst.elements(3).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(src[(int) idx[0]][(int) idx[1]][(int) idx[2]][(int) idx[3]]).copyTo(e)
+        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]]).copyTo(e)
     );
   }
 
@@ -1567,12 +1569,12 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-6 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-6 or has an incompatible shape with the source
-   * array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-6 or has an incompatible shape
+   *                                  with the source array
    */
   public static void copyTo(float[][][][][][] src, FloatNdArray dst) {
     dst.elements(4).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(src[(int) idx[0]][(int) idx[1]][(int) idx[2]][(int) idx[3]][(int) idx[4]]).copyTo(e)
+        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]][(int)idx[4]]).copyTo(e)
     );
   }
 
@@ -1581,8 +1583,8 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-1 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-1 or has an incompatible shape with the source
-   * array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-1 or has an incompatible shape
+   *                                  with the source array
    */
   public static void copyTo(double[] src, DoubleNdArray dst) {
     NdArrays.vectorOf(src).copyTo(dst);
@@ -1593,12 +1595,12 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-2 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-2 or has an incompatible shape with the source
-   * array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-2 or has an incompatible shape
+   *                                  with the source array
    */
   public static void copyTo(double[][] src, DoubleNdArray dst) {
     dst.elements(0).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(src[(int) idx[0]]).copyTo(e)
+        NdArrays.vectorOf(src[(int)idx[0]]).copyTo(e)
     );
   }
 
@@ -1607,12 +1609,12 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-3 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-3 or has an incompatible shape with the source
-   * array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-3 or has an incompatible shape
+   *                                  with the source array
    */
   public static void copyTo(double[][][] src, DoubleNdArray dst) {
     dst.elements(1).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(src[(int) idx[0]][(int) idx[1]]).copyTo(e)
+        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]]).copyTo(e)
     );
   }
 
@@ -1621,12 +1623,12 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-4 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-4 or has an incompatible shape with the source
-   * array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-4 or has an incompatible shape
+   *                                  with the source array
    */
   public static void copyTo(double[][][][] src, DoubleNdArray dst) {
     dst.elements(2).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(src[(int) idx[0]][(int) idx[1]][(int) idx[2]]).copyTo(e)
+        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]][(int)idx[2]]).copyTo(e)
     );
   }
 
@@ -1635,12 +1637,12 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-5 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-5 or has an incompatible shape with the source
-   * array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-5 or has an incompatible shape
+   *                                  with the source array
    */
   public static void copyTo(double[][][][][] src, DoubleNdArray dst) {
     dst.elements(3).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(src[(int) idx[0]][(int) idx[1]][(int) idx[2]][(int) idx[3]]).copyTo(e)
+        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]]).copyTo(e)
     );
   }
 
@@ -1649,12 +1651,12 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-6 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-6 or has an incompatible shape with the source
-   * array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-6 or has an incompatible shape
+   *                                  with the source array
    */
   public static void copyTo(double[][][][][][] src, DoubleNdArray dst) {
     dst.elements(4).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(src[(int) idx[0]][(int) idx[1]][(int) idx[2]][(int) idx[3]][(int) idx[4]]).copyTo(e)
+        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]][(int)idx[4]]).copyTo(e)
     );
   }
 
@@ -1663,8 +1665,8 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-1 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-1 or has an incompatible shape with the source
-   * array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-1 or has an incompatible shape
+   *                                  with the source array
    */
   public static void copyTo(byte[] src, ByteNdArray dst) {
     NdArrays.vectorOf(src).copyTo(dst);
@@ -1675,12 +1677,12 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-2 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-2 or has an incompatible shape with the source
-   * array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-2 or has an incompatible shape
+   *                                  with the source array
    */
   public static void copyTo(byte[][] src, ByteNdArray dst) {
     dst.elements(0).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(src[(int) idx[0]]).copyTo(e)
+        NdArrays.vectorOf(src[(int)idx[0]]).copyTo(e)
     );
   }
 
@@ -1689,12 +1691,12 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-3 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-3 or has an incompatible shape with the source
-   * array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-3 or has an incompatible shape
+   *                                  with the source array
    */
   public static void copyTo(byte[][][] src, ByteNdArray dst) {
     dst.elements(1).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(src[(int) idx[0]][(int) idx[1]]).copyTo(e)
+        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]]).copyTo(e)
     );
   }
 
@@ -1703,12 +1705,12 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-4 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-4 or has an incompatible shape with the source
-   * array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-4 or has an incompatible shape
+   *                                  with the source array
    */
   public static void copyTo(byte[][][][] src, ByteNdArray dst) {
     dst.elements(2).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(src[(int) idx[0]][(int) idx[1]][(int) idx[2]]).copyTo(e)
+        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]][(int)idx[2]]).copyTo(e)
     );
   }
 
@@ -1717,12 +1719,12 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-5 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-5 or has an incompatible shape with the source
-   * array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-5 or has an incompatible shape
+   *                                  with the source array
    */
   public static void copyTo(byte[][][][][] src, ByteNdArray dst) {
     dst.elements(3).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(src[(int) idx[0]][(int) idx[1]][(int) idx[2]][(int) idx[3]]).copyTo(e)
+        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]]).copyTo(e)
     );
   }
 
@@ -1731,12 +1733,12 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-6 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-6 or has an incompatible shape with the source
-   * array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-6 or has an incompatible shape
+   *                                  with the source array
    */
   public static void copyTo(byte[][][][][][] src, ByteNdArray dst) {
     dst.elements(4).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(src[(int) idx[0]][(int) idx[1]][(int) idx[2]][(int) idx[3]][(int) idx[4]]).copyTo(e)
+        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]][(int)idx[4]]).copyTo(e)
     );
   }
 
@@ -1745,8 +1747,8 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-1 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-1 or has an incompatible shape with the source
-   * array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-1 or has an incompatible shape
+   *                                  with the source array
    */
   public static void copyTo(short[] src, ShortNdArray dst) {
     NdArrays.vectorOf(src).copyTo(dst);
@@ -1757,12 +1759,12 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-2 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-2 or has an incompatible shape with the source
-   * array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-2 or has an incompatible shape
+   *                                  with the source array
    */
   public static void copyTo(short[][] src, ShortNdArray dst) {
     dst.elements(0).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(src[(int) idx[0]]).copyTo(e)
+        NdArrays.vectorOf(src[(int)idx[0]]).copyTo(e)
     );
   }
 
@@ -1771,12 +1773,12 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-3 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-3 or has an incompatible shape with the source
-   * array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-3 or has an incompatible shape
+   *                                  with the source array
    */
   public static void copyTo(short[][][] src, ShortNdArray dst) {
     dst.elements(1).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(src[(int) idx[0]][(int) idx[1]]).copyTo(e)
+        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]]).copyTo(e)
     );
   }
 
@@ -1785,12 +1787,12 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-4 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-4 or has an incompatible shape with the source
-   * array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-4 or has an incompatible shape
+   *                                  with the source array
    */
   public static void copyTo(short[][][][] src, ShortNdArray dst) {
     dst.elements(2).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(src[(int) idx[0]][(int) idx[1]][(int) idx[2]]).copyTo(e)
+        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]][(int)idx[2]]).copyTo(e)
     );
   }
 
@@ -1799,12 +1801,12 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-5 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-5 or has an incompatible shape with the source
-   * array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-5 or has an incompatible shape
+   *                                  with the source array
    */
   public static void copyTo(short[][][][][] src, ShortNdArray dst) {
     dst.elements(3).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(src[(int) idx[0]][(int) idx[1]][(int) idx[2]][(int) idx[3]]).copyTo(e)
+        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]]).copyTo(e)
     );
   }
 
@@ -1813,12 +1815,12 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-6 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-6 or has an incompatible shape with the source
-   * array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-6 or has an incompatible shape
+   *                                  with the source array
    */
   public static void copyTo(short[][][][][][] src, ShortNdArray dst) {
     dst.elements(4).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(src[(int) idx[0]][(int) idx[1]][(int) idx[2]][(int) idx[3]][(int) idx[4]]).copyTo(e)
+        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]][(int)idx[4]]).copyTo(e)
     );
   }
 
@@ -1827,8 +1829,8 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-1 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-1 or has an incompatible shape with the source
-   * array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-1 or has an incompatible shape
+   *                                  with the source array
    */
   public static void copyTo(boolean[] src, BooleanNdArray dst) {
     NdArrays.vectorOf(src).copyTo(dst);
@@ -1839,12 +1841,12 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-2 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-2 or has an incompatible shape with the source
-   * array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-2 or has an incompatible shape
+   *                                  with the source array
    */
   public static void copyTo(boolean[][] src, BooleanNdArray dst) {
     dst.elements(0).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(src[(int) idx[0]]).copyTo(e)
+        NdArrays.vectorOf(src[(int)idx[0]]).copyTo(e)
     );
   }
 
@@ -1853,12 +1855,12 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-3 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-3 or has an incompatible shape with the source
-   * array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-3 or has an incompatible shape
+   *                                  with the source array
    */
   public static void copyTo(boolean[][][] src, BooleanNdArray dst) {
     dst.elements(1).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(src[(int) idx[0]][(int) idx[1]]).copyTo(e)
+        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]]).copyTo(e)
     );
   }
 
@@ -1867,12 +1869,12 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-4 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-4 or has an incompatible shape with the source
-   * array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-4 or has an incompatible shape
+   *                                  with the source array
    */
   public static void copyTo(boolean[][][][] src, BooleanNdArray dst) {
     dst.elements(2).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(src[(int) idx[0]][(int) idx[1]][(int) idx[2]]).copyTo(e)
+        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]][(int)idx[2]]).copyTo(e)
     );
   }
 
@@ -1881,12 +1883,12 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-5 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-5 or has an incompatible shape with the source
-   * array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-5 or has an incompatible shape
+   *                                  with the source array
    */
   public static void copyTo(boolean[][][][][] src, BooleanNdArray dst) {
     dst.elements(3).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(src[(int) idx[0]][(int) idx[1]][(int) idx[2]][(int) idx[3]]).copyTo(e)
+        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]]).copyTo(e)
     );
   }
 
@@ -1895,12 +1897,12 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-6 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-6 or has an incompatible shape with the source
-   * array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-6 or has an incompatible shape
+   *                                  with the source array
    */
   public static void copyTo(boolean[][][][][][] src, BooleanNdArray dst) {
     dst.elements(4).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(src[(int) idx[0]][(int) idx[1]][(int) idx[2]][(int) idx[3]][(int) idx[4]]).copyTo(e)
+        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]][(int)idx[4]]).copyTo(e)
     );
   }
 
@@ -1910,8 +1912,8 @@ public final class StdArrays {
    * @param src source array
    * @param dst destination rank-1 array
    * @param <T> data type
-   * @throws IllegalArgumentException if {@code dst} is not of rank-1 or has an incompatible shape with the source
-   * array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-1 or has an incompatible shape
+   *                                  with the source array
    */
   public static <T> void copyTo(T[] src, NdArray<T> dst) {
     NdArrays.vectorOfObjects(src).copyTo(dst);
@@ -1923,12 +1925,12 @@ public final class StdArrays {
    * @param src source array
    * @param dst destination rank-2 array
    * @param <T> data type
-   * @throws IllegalArgumentException if {@code dst} is not of rank-2 or has an incompatible shape with the source
-   * array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-2 or has an incompatible shape
+   *                                  with the source array
    */
   public static <T> void copyTo(T[][] src, NdArray<T> dst) {
     dst.elements(0).forEachIndexed((idx, e) ->
-        NdArrays.vectorOfObjects(src[(int) idx[0]]).copyTo(e)
+        NdArrays.vectorOfObjects(src[(int)idx[0]]).copyTo(e)
     );
   }
 
@@ -1938,12 +1940,12 @@ public final class StdArrays {
    * @param src source array
    * @param dst destination rank-3 array
    * @param <T> data type
-   * @throws IllegalArgumentException if {@code dst} is not of rank-3 or has an incompatible shape with the source
-   * array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-3 or has an incompatible shape
+   *                                  with the source array
    */
   public static <T> void copyTo(T[][][] src, NdArray<T> dst) {
     dst.elements(1).forEachIndexed((idx, e) ->
-        NdArrays.vectorOfObjects(src[(int) idx[0]][(int) idx[1]]).copyTo(e)
+        NdArrays.vectorOfObjects(src[(int)idx[0]][(int)idx[1]]).copyTo(e)
     );
   }
 
@@ -1953,12 +1955,12 @@ public final class StdArrays {
    * @param src source array
    * @param dst destination rank-4 array
    * @param <T> data type
-   * @throws IllegalArgumentException if {@code dst} is not of rank-4 or has an incompatible shape with the source
-   * array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-4 or has an incompatible shape
+   *                                  with the source array
    */
   public static <T> void copyTo(T[][][][] src, NdArray<T> dst) {
     dst.elements(2).forEachIndexed((idx, e) ->
-        NdArrays.vectorOfObjects(src[(int) idx[0]][(int) idx[1]][(int) idx[2]]).copyTo(e)
+        NdArrays.vectorOfObjects(src[(int)idx[0]][(int)idx[1]][(int)idx[2]]).copyTo(e)
     );
   }
 
@@ -1968,12 +1970,12 @@ public final class StdArrays {
    * @param src source array
    * @param dst destination rank-5 array
    * @param <T> data type
-   * @throws IllegalArgumentException if {@code dst} is not of rank-5 or has an incompatible shape with the source
-   * array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-5 or has an incompatible shape
+   *                                  with the source array
    */
   public static <T> void copyTo(T[][][][][] src, NdArray<T> dst) {
     dst.elements(3).forEachIndexed((idx, e) ->
-        NdArrays.vectorOfObjects(src[(int) idx[0]][(int) idx[1]][(int) idx[2]][(int) idx[3]]).copyTo(e)
+        NdArrays.vectorOfObjects(src[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]]).copyTo(e)
     );
   }
 
@@ -1983,12 +1985,12 @@ public final class StdArrays {
    * @param src source array
    * @param dst destination rank-6 array
    * @param <T> data type
-   * @throws IllegalArgumentException if {@code dst} is not of rank-6 or has an incompatible shape with the source
-   * array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-6 or has an incompatible shape
+   *                                  with the source array
    */
   public static <T> void copyTo(T[][][][][][] src, NdArray<T> dst) {
     dst.elements(4).forEachIndexed((idx, e) ->
-        NdArrays.vectorOfObjects(src[(int) idx[0]][(int) idx[1]][(int) idx[2]][(int) idx[3]][(int) idx[4]]).copyTo(e)
+        NdArrays.vectorOfObjects(src[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]][(int)idx[4]]).copyTo(e)
     );
   }
 
@@ -2024,7 +2026,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(0).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int) idx[0]])
+        copyFrom(e, dst[(int)idx[0]])
     );
   }
 
@@ -2041,7 +2043,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(1).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int) idx[0]][(int) idx[1]])
+        copyFrom(e, dst[(int)idx[0]][(int)idx[1]])
     );
   }
 
@@ -2058,7 +2060,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(2).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int) idx[0]][(int) idx[1]][(int) idx[2]])
+        copyFrom(e, dst[(int)idx[0]][(int)idx[1]][(int)idx[2]])
     );
   }
 
@@ -2075,7 +2077,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(3).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int) idx[0]][(int) idx[1]][(int) idx[2]][(int) idx[3]])
+        copyFrom(e, dst[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]])
     );
   }
 
@@ -2092,7 +2094,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(4).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int) idx[0]][(int) idx[1]][(int) idx[2]][(int) idx[3]][(int) idx[4]])
+        copyFrom(e, dst[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]][(int)idx[4]])
     );
   }
 
@@ -2127,7 +2129,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(0).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int) idx[0]])
+        copyFrom(e, dst[(int)idx[0]])
     );
   }
 
@@ -2144,7 +2146,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(1).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int) idx[0]][(int) idx[1]])
+        copyFrom(e, dst[(int)idx[0]][(int)idx[1]])
     );
   }
 
@@ -2161,7 +2163,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(2).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int) idx[0]][(int) idx[1]][(int) idx[2]])
+        copyFrom(e, dst[(int)idx[0]][(int)idx[1]][(int)idx[2]])
     );
   }
 
@@ -2178,7 +2180,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(3).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int) idx[0]][(int) idx[1]][(int) idx[2]][(int) idx[3]])
+        copyFrom(e, dst[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]])
     );
   }
 
@@ -2195,7 +2197,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(4).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int) idx[0]][(int) idx[1]][(int) idx[2]][(int) idx[3]][(int) idx[4]])
+        copyFrom(e, dst[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]][(int)idx[4]])
     );
   }
 
@@ -2230,7 +2232,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(0).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int) idx[0]])
+        copyFrom(e, dst[(int)idx[0]])
     );
   }
 
@@ -2247,7 +2249,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(1).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int) idx[0]][(int) idx[1]])
+        copyFrom(e, dst[(int)idx[0]][(int)idx[1]])
     );
   }
 
@@ -2264,7 +2266,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(2).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int) idx[0]][(int) idx[1]][(int) idx[2]])
+        copyFrom(e, dst[(int)idx[0]][(int)idx[1]][(int)idx[2]])
     );
   }
 
@@ -2281,7 +2283,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(3).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int) idx[0]][(int) idx[1]][(int) idx[2]][(int) idx[3]])
+        copyFrom(e, dst[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]])
     );
   }
 
@@ -2298,7 +2300,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(4).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int) idx[0]][(int) idx[1]][(int) idx[2]][(int) idx[3]][(int) idx[4]])
+        copyFrom(e, dst[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]][(int)idx[4]])
     );
   }
 
@@ -2333,7 +2335,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(0).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int) idx[0]])
+        copyFrom(e, dst[(int)idx[0]])
     );
   }
 
@@ -2350,7 +2352,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(1).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int) idx[0]][(int) idx[1]])
+        copyFrom(e, dst[(int)idx[0]][(int)idx[1]])
     );
   }
 
@@ -2367,7 +2369,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(2).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int) idx[0]][(int) idx[1]][(int) idx[2]])
+        copyFrom(e, dst[(int)idx[0]][(int)idx[1]][(int)idx[2]])
     );
   }
 
@@ -2384,7 +2386,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(3).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int) idx[0]][(int) idx[1]][(int) idx[2]][(int) idx[3]])
+        copyFrom(e, dst[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]])
     );
   }
 
@@ -2401,7 +2403,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(4).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int) idx[0]][(int) idx[1]][(int) idx[2]][(int) idx[3]][(int) idx[4]])
+        copyFrom(e, dst[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]][(int)idx[4]])
     );
   }
 
@@ -2436,7 +2438,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(0).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int) idx[0]])
+        copyFrom(e, dst[(int)idx[0]])
     );
   }
 
@@ -2453,7 +2455,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(1).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int) idx[0]][(int) idx[1]])
+        copyFrom(e, dst[(int)idx[0]][(int)idx[1]])
     );
   }
 
@@ -2470,7 +2472,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(2).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int) idx[0]][(int) idx[1]][(int) idx[2]])
+        copyFrom(e, dst[(int)idx[0]][(int)idx[1]][(int)idx[2]])
     );
   }
 
@@ -2487,7 +2489,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(3).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int) idx[0]][(int) idx[1]][(int) idx[2]][(int) idx[3]])
+        copyFrom(e, dst[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]])
     );
   }
 
@@ -2504,7 +2506,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(4).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int) idx[0]][(int) idx[1]][(int) idx[2]][(int) idx[3]][(int) idx[4]])
+        copyFrom(e, dst[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]][(int)idx[4]])
     );
   }
 
@@ -2539,7 +2541,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(0).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int) idx[0]])
+        copyFrom(e, dst[(int)idx[0]])
     );
   }
 
@@ -2556,7 +2558,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(1).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int) idx[0]][(int) idx[1]])
+        copyFrom(e, dst[(int)idx[0]][(int)idx[1]])
     );
   }
 
@@ -2573,7 +2575,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(2).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int) idx[0]][(int) idx[1]][(int) idx[2]])
+        copyFrom(e, dst[(int)idx[0]][(int)idx[1]][(int)idx[2]])
     );
   }
 
@@ -2590,7 +2592,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(3).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int) idx[0]][(int) idx[1]][(int) idx[2]][(int) idx[3]])
+        copyFrom(e, dst[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]])
     );
   }
 
@@ -2607,7 +2609,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(4).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int) idx[0]][(int) idx[1]][(int) idx[2]][(int) idx[3]][(int) idx[4]])
+        copyFrom(e, dst[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]][(int)idx[4]])
     );
   }
 
@@ -2642,7 +2644,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(0).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int) idx[0]])
+        copyFrom(e, dst[(int)idx[0]])
     );
   }
 
@@ -2659,7 +2661,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(1).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int) idx[0]][(int) idx[1]])
+        copyFrom(e, dst[(int)idx[0]][(int)idx[1]])
     );
   }
 
@@ -2676,7 +2678,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(2).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int) idx[0]][(int) idx[1]][(int) idx[2]])
+        copyFrom(e, dst[(int)idx[0]][(int)idx[1]][(int)idx[2]])
     );
   }
 
@@ -2693,7 +2695,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(3).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int) idx[0]][(int) idx[1]][(int) idx[2]][(int) idx[3]])
+        copyFrom(e, dst[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]])
     );
   }
 
@@ -2710,7 +2712,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(4).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int) idx[0]][(int) idx[1]][(int) idx[2]][(int) idx[3]][(int) idx[4]])
+        copyFrom(e, dst[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]][(int)idx[4]])
     );
   }
 
@@ -2747,7 +2749,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(0).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int) idx[0]])
+        copyFrom(e, dst[(int)idx[0]])
     );
   }
 
@@ -2765,7 +2767,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(1).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int) idx[0]][(int) idx[1]])
+        copyFrom(e, dst[(int)idx[0]][(int)idx[1]])
     );
   }
 
@@ -2783,7 +2785,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(2).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int) idx[0]][(int) idx[1]][(int) idx[2]])
+        copyFrom(e, dst[(int)idx[0]][(int)idx[1]][(int)idx[2]])
     );
   }
 
@@ -2801,7 +2803,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(3).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int) idx[0]][(int) idx[1]][(int) idx[2]][(int) idx[3]])
+        copyFrom(e, dst[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]])
     );
   }
 
@@ -2819,7 +2821,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(4).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int) idx[0]][(int) idx[1]][(int) idx[2]][(int) idx[3]][(int) idx[4]])
+        copyFrom(e, dst[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]][(int)idx[4]])
     );
   }
 
@@ -3786,7 +3788,7 @@ public final class StdArrays {
     while (componentType.isArray()) {
       componentType = componentType.getComponentType();
     }
-    return (Class<T>) componentType;
+    return (Class<T>)componentType;
   }
 
   private static int[] computeArrayDims(NdArray<?> ndArray, int expectedRank) {
@@ -3798,10 +3800,9 @@ public final class StdArrays {
     for (int i = 0; i < expectedRank; ++i) {
       long dimSize = shape.get(i);
       if (dimSize > Integer.MAX_VALUE) {
-        throw new IllegalArgumentException(
-            "Dimension " + i + " is too large to fit in a standard array (" + shape.get(i) + ")");
+        throw new IllegalArgumentException("Dimension " + i + " is too large to fit in a standard array (" + shape.size(i) + ")");
       }
-      arrayShape[i] = (int) dimSize;
+      arrayShape[i] = (int)dimSize;
     }
     return arrayShape;
   }

--- a/ndarray/src/main/java/org/tensorflow/ndarray/StdArrays.java
+++ b/ndarray/src/main/java/org/tensorflow/ndarray/StdArrays.java
@@ -1,7 +1,5 @@
 package org.tensorflow.ndarray;
 
-import static org.tensorflow.ndarray.NdArrays.vectorOf;
-
 import java.lang.reflect.Array;
 import org.tensorflow.ndarray.buffer.DataBuffers;
 
@@ -537,7 +535,7 @@ public final class StdArrays {
    */
   public static <T> NdArray<T> ndCopyOf(T[][] array) {
     @SuppressWarnings("unchecked")
-    NdArray<T>ndArray = NdArrays.ofObjects(componentTypeOf(array), shapeOf(array));
+    NdArray<T> ndArray = NdArrays.ofObjects(componentTypeOf(array), shapeOf(array));
     copyTo(array, ndArray);
     return ndArray;
   }
@@ -551,7 +549,7 @@ public final class StdArrays {
    */
   public static <T> NdArray<T> ndCopyOf(T[][][] array) {
     @SuppressWarnings("unchecked")
-    NdArray<T>ndArray = NdArrays.ofObjects(componentTypeOf(array), shapeOf(array));
+    NdArray<T> ndArray = NdArrays.ofObjects(componentTypeOf(array), shapeOf(array));
     copyTo(array, ndArray);
     return ndArray;
   }
@@ -565,7 +563,7 @@ public final class StdArrays {
    */
   public static <T> NdArray<T> ndCopyOf(T[][][][] array) {
     @SuppressWarnings("unchecked")
-    NdArray<T>ndArray = NdArrays.ofObjects(componentTypeOf(array), shapeOf(array));
+    NdArray<T> ndArray = NdArrays.ofObjects(componentTypeOf(array), shapeOf(array));
     copyTo(array, ndArray);
     return ndArray;
   }
@@ -579,7 +577,7 @@ public final class StdArrays {
    */
   public static <T> NdArray<T> ndCopyOf(T[][][][][] array) {
     @SuppressWarnings("unchecked")
-    NdArray<T>ndArray = NdArrays.ofObjects(componentTypeOf(array), shapeOf(array));
+    NdArray<T> ndArray = NdArrays.ofObjects(componentTypeOf(array), shapeOf(array));
     copyTo(array, ndArray);
     return ndArray;
   }
@@ -593,7 +591,7 @@ public final class StdArrays {
    */
   public static <T> NdArray<T> ndCopyOf(T[][][][][][] array) {
     @SuppressWarnings("unchecked")
-    NdArray<T>ndArray = NdArrays.ofObjects(componentTypeOf(array), shapeOf(array));
+    NdArray<T> ndArray = NdArrays.ofObjects(componentTypeOf(array), shapeOf(array));
     copyTo(array, ndArray);
     return ndArray;
   }
@@ -603,8 +601,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-1 or has a shape that
-   *                                  exceeds standard arrays limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-1 or has a shape that exceeds standard arrays
+   * limits
    */
   public static int[] array1dCopyOf(IntNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 1);
@@ -618,8 +616,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-2 or has a shape that
-   *                                  exceeds standard arrays limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-2 or has a shape that exceeds standard arrays
+   * limits
    */
   public static int[][] array2dCopyOf(IntNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 2);
@@ -633,8 +631,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-3 or has a shape that
-   *                                  exceeds standard arrays limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-3 or has a shape that exceeds standard arrays
+   * limits
    */
   public static int[][][] array3dCopyOf(IntNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 3);
@@ -648,8 +646,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-4 or has a shape that
-   *                                  exceeds standard arrays limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-4 or has a shape that exceeds standard arrays
+   * limits
    */
   public static int[][][][] array4dCopyOf(IntNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 4);
@@ -663,8 +661,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-5 or has a shape that
-   *                                  exceeds standard arrays limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-5 or has a shape that exceeds standard arrays
+   * limits
    */
   public static int[][][][][] array5dCopyOf(IntNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 5);
@@ -678,8 +676,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-6 or has a shape that
-   *                                  exceeds standard arrays limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-6 or has a shape that exceeds standard arrays
+   * limits
    */
   public static int[][][][][][] array6dCopyOf(IntNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 6);
@@ -693,8 +691,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-1 or has a shape that
-   *                                  exceeds standard arrays limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-1 or has a shape that exceeds standard arrays
+   * limits
    */
   public static long[] array1dCopyOf(LongNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 1);
@@ -708,8 +706,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-2 or has a shape that
-   *                                  exceeds standard arrays limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-2 or has a shape that exceeds standard arrays
+   * limits
    */
   public static long[][] array2dCopyOf(LongNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 2);
@@ -723,8 +721,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-3 or has a shape that
-   *                                  exceeds standard arrays limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-3 or has a shape that exceeds standard arrays
+   * limits
    */
   public static long[][][] array3dCopyOf(LongNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 3);
@@ -738,8 +736,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-4 or has a shape that
-   *                                  exceeds standard arrays limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-4 or has a shape that exceeds standard arrays
+   * limits
    */
   public static long[][][][] array4dCopyOf(LongNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 4);
@@ -753,8 +751,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-5 or has a shape that
-   *                                  exceeds standard arrays limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-5 or has a shape that exceeds standard arrays
+   * limits
    */
   public static long[][][][][] array5dCopyOf(LongNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 5);
@@ -768,8 +766,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-6 or has a shape that
-   *                                  exceeds standard arrays limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-6 or has a shape that exceeds standard arrays
+   * limits
    */
   public static long[][][][][][] array6dCopyOf(LongNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 6);
@@ -783,8 +781,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-1 or has a shape that
-   *                                  exceeds standard arrays limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-1 or has a shape that exceeds standard arrays
+   * limits
    */
   public static float[] array1dCopyOf(FloatNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 1);
@@ -798,8 +796,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-2 or has a shape that
-   *                                  exceeds standard arrays limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-2 or has a shape that exceeds standard arrays
+   * limits
    */
   public static float[][] array2dCopyOf(FloatNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 2);
@@ -813,8 +811,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-3 or has a shape that
-   *                                  exceeds standard arrays limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-3 or has a shape that exceeds standard arrays
+   * limits
    */
   public static float[][][] array3dCopyOf(FloatNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 3);
@@ -828,8 +826,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-4 or has a shape that
-   *                                  exceeds standard arrays limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-4 or has a shape that exceeds standard arrays
+   * limits
    */
   public static float[][][][] array4dCopyOf(FloatNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 4);
@@ -843,8 +841,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-5 or has a shape that
-   *                                  exceeds standard arrays limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-5 or has a shape that exceeds standard arrays
+   * limits
    */
   public static float[][][][][] array5dCopyOf(FloatNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 5);
@@ -858,8 +856,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-6 or has a shape that
-   *                                  exceeds standard arrays limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-6 or has a shape that exceeds standard arrays
+   * limits
    */
   public static float[][][][][][] array6dCopyOf(FloatNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 6);
@@ -873,8 +871,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-1 or has a shape that
-   *                                  exceeds standard arrays limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-1 or has a shape that exceeds standard arrays
+   * limits
    */
   public static double[] array1dCopyOf(DoubleNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 1);
@@ -888,8 +886,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-2 or has a shape that
-   *                                  exceeds standard arrays limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-2 or has a shape that exceeds standard arrays
+   * limits
    */
   public static double[][] array2dCopyOf(DoubleNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 2);
@@ -903,8 +901,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-3 or has a shape that
-   *                                  exceeds standard arrays limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-3 or has a shape that exceeds standard arrays
+   * limits
    */
   public static double[][][] array3dCopyOf(DoubleNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 3);
@@ -918,8 +916,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-4 or has a shape that
-   *                                  exceeds standard arrays limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-4 or has a shape that exceeds standard arrays
+   * limits
    */
   public static double[][][][] array4dCopyOf(DoubleNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 4);
@@ -933,8 +931,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-5 or has a shape that
-   *                                  exceeds standard arrays limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-5 or has a shape that exceeds standard arrays
+   * limits
    */
   public static double[][][][][] array5dCopyOf(DoubleNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 5);
@@ -948,8 +946,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-6 or has a shape that
-   *                                  exceeds standard arrays limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-6 or has a shape that exceeds standard arrays
+   * limits
    */
   public static double[][][][][][] array6dCopyOf(DoubleNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 6);
@@ -963,8 +961,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-1 or has a shape that
-   *                                  exceeds standard arrays limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-1 or has a shape that exceeds standard arrays
+   * limits
    */
   public static byte[] array1dCopyOf(ByteNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 1);
@@ -978,8 +976,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-2 or has a shape that
-   *                                  exceeds standard arrays limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-2 or has a shape that exceeds standard arrays
+   * limits
    */
   public static byte[][] array2dCopyOf(ByteNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 2);
@@ -993,8 +991,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-3 or has a shape that
-   *                                  exceeds standard arrays limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-3 or has a shape that exceeds standard arrays
+   * limits
    */
   public static byte[][][] array3dCopyOf(ByteNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 3);
@@ -1008,8 +1006,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-4 or has a shape that
-   *                                  exceeds standard arrays limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-4 or has a shape that exceeds standard arrays
+   * limits
    */
   public static byte[][][][] array4dCopyOf(ByteNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 4);
@@ -1023,8 +1021,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-5 or has a shape that
-   *                                  exceeds standard arrays limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-5 or has a shape that exceeds standard arrays
+   * limits
    */
   public static byte[][][][][] array5dCopyOf(ByteNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 5);
@@ -1038,8 +1036,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-6 or has a shape that
-   *                                  exceeds standard arrays limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-6 or has a shape that exceeds standard arrays
+   * limits
    */
   public static byte[][][][][][] array6dCopyOf(ByteNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 6);
@@ -1053,8 +1051,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-1 or has a shape that
-   *                                  exceeds standard arrays limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-1 or has a shape that exceeds standard arrays
+   * limits
    */
   public static short[] array1dCopyOf(ShortNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 1);
@@ -1068,8 +1066,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-2 or has a shape that
-   *                                  exceeds standard arrays limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-2 or has a shape that exceeds standard arrays
+   * limits
    */
   public static short[][] array2dCopyOf(ShortNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 2);
@@ -1083,8 +1081,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-3 or has a shape that
-   *                                  exceeds standard arrays limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-3 or has a shape that exceeds standard arrays
+   * limits
    */
   public static short[][][] array3dCopyOf(ShortNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 3);
@@ -1098,8 +1096,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-4 or has a shape that
-   *                                  exceeds standard arrays limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-4 or has a shape that exceeds standard arrays
+   * limits
    */
   public static short[][][][] array4dCopyOf(ShortNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 4);
@@ -1113,8 +1111,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-5 or has a shape that
-   *                                  exceeds standard arrays limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-5 or has a shape that exceeds standard arrays
+   * limits
    */
   public static short[][][][][] array5dCopyOf(ShortNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 5);
@@ -1128,8 +1126,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-6 or has a shape that
-   *                                  exceeds standard arrays limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-6 or has a shape that exceeds standard arrays
+   * limits
    */
   public static short[][][][][][] array6dCopyOf(ShortNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 6);
@@ -1143,8 +1141,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-1 or has a shape that
-   *                                  exceeds standard arrays limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-1 or has a shape that exceeds standard arrays
+   * limits
    */
   public static boolean[] array1dCopyOf(BooleanNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 1);
@@ -1158,8 +1156,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-2 or has a shape that
-   *                                  exceeds standard arrays limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-2 or has a shape that exceeds standard arrays
+   * limits
    */
   public static boolean[][] array2dCopyOf(BooleanNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 2);
@@ -1173,8 +1171,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-3 or has a shape that
-   *                                  exceeds standard arrays limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-3 or has a shape that exceeds standard arrays
+   * limits
    */
   public static boolean[][][] array3dCopyOf(BooleanNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 3);
@@ -1188,8 +1186,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-4 or has a shape that
-   *                                  exceeds standard arrays limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-4 or has a shape that exceeds standard arrays
+   * limits
    */
   public static boolean[][][][] array4dCopyOf(BooleanNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 4);
@@ -1203,8 +1201,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-5 or has a shape that
-   *                                  exceeds standard arrays limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-5 or has a shape that exceeds standard arrays
+   * limits
    */
   public static boolean[][][][][] array5dCopyOf(BooleanNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 5);
@@ -1218,8 +1216,8 @@ public final class StdArrays {
    *
    * @param ndArray source array
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-6 or has a shape that
-   *                                  exceeds standard arrays limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-6 or has a shape that exceeds standard arrays
+   * limits
    */
   public static boolean[][][][][][] array6dCopyOf(BooleanNdArray ndArray) {
     int[] dims = computeArrayDims(ndArray, 6);
@@ -1235,12 +1233,12 @@ public final class StdArrays {
    * @param objectType type of object
    * @param <T> data type
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-1 or has a shape that
-   *                                  exceeds standard arrays limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-1 or has a shape that exceeds standard arrays
+   * limits
    */
   public static <T> T[] array1dCopyOf(NdArray<T> ndArray, Class<T> objectType) {
     int[] dims = computeArrayDims(ndArray, 1);
-    T[] array = (T[])Array.newInstance(objectType, dims[0]);
+    T[] array = (T[]) Array.newInstance(objectType, dims[0]);
     copyFrom(ndArray, array);
     return array;
   }
@@ -1252,12 +1250,12 @@ public final class StdArrays {
    * @param objectType type of object
    * @param <T> data type
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-2 or has a shape that
-   *                                  exceeds standard arrays limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-2 or has a shape that exceeds standard arrays
+   * limits
    */
   public static <T> T[][] array2dCopyOf(NdArray<T> ndArray, Class<T> objectType) {
     int[] dims = computeArrayDims(ndArray, 2);
-    T[][] array = (T[][])Array.newInstance(objectType, dims[0], dims[1]);
+    T[][] array = (T[][]) Array.newInstance(objectType, dims[0], dims[1]);
     copyFrom(ndArray, array);
     return array;
   }
@@ -1269,12 +1267,12 @@ public final class StdArrays {
    * @param objectType type of object
    * @param <T> data type
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-3 or has a shape that
-   *                                  exceeds standard arrays limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-3 or has a shape that exceeds standard arrays
+   * limits
    */
   public static <T> T[][][] array3dCopyOf(NdArray<T> ndArray, Class<T> objectType) {
     int[] dims = computeArrayDims(ndArray, 3);
-    T[][][] array = (T[][][])Array.newInstance(objectType, dims[0], dims[1], dims[2]);
+    T[][][] array = (T[][][]) Array.newInstance(objectType, dims[0], dims[1], dims[2]);
     copyFrom(ndArray, array);
     return array;
   }
@@ -1286,12 +1284,12 @@ public final class StdArrays {
    * @param objectType type of object
    * @param <T> data type
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-4 or has a shape that
-   *                                  exceeds standard arrays limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-4 or has a shape that exceeds standard arrays
+   * limits
    */
   public static <T> T[][][][] array4dCopyOf(NdArray<T> ndArray, Class<T> objectType) {
     int[] dims = computeArrayDims(ndArray, 4);
-    T[][][][] array = (T[][][][])Array.newInstance(objectType, dims[0], dims[1], dims[2], dims[3]);
+    T[][][][] array = (T[][][][]) Array.newInstance(objectType, dims[0], dims[1], dims[2], dims[3]);
     copyFrom(ndArray, array);
     return array;
   }
@@ -1303,13 +1301,13 @@ public final class StdArrays {
    * @param objectType type of object
    * @param <T> data type
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-5 or has a shape that
-   *                                  exceeds standard arrays limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-5 or has a shape that exceeds standard arrays
+   * limits
    */
   public static <T> T[][][][][] array5dCopyOf(NdArray<T> ndArray, Class<T> objectType) {
     int[] dims = computeArrayDims(ndArray, 5);
     T[][][][][] array =
-        (T[][][][][])Array.newInstance(objectType, dims[0], dims[1], dims[2], dims[3], dims[4]);
+        (T[][][][][]) Array.newInstance(objectType, dims[0], dims[1], dims[2], dims[3], dims[4]);
     copyFrom(ndArray, array);
     return array;
   }
@@ -1321,13 +1319,13 @@ public final class StdArrays {
    * @param objectType type of object
    * @param <T> data type
    * @return the array copy
-   * @throws IllegalArgumentException if {@code ndArray} is not of rank-6 or has a shape that
-   *                                  exceeds standard arrays limits
+   * @throws IllegalArgumentException if {@code ndArray} is not of rank-6 or has a shape that exceeds standard arrays
+   * limits
    */
   public static <T> T[][][][][][] array6dCopyOf(NdArray<T> ndArray, Class<T> objectType) {
     int[] dims = computeArrayDims(ndArray, 6);
     T[][][][][][] array =
-        (T[][][][][][])Array.newInstance(objectType, dims[0], dims[1], dims[2], dims[3], dims[4], dims[5]);
+        (T[][][][][][]) Array.newInstance(objectType, dims[0], dims[1], dims[2], dims[3], dims[4], dims[5]);
     copyFrom(ndArray, array);
     return array;
   }
@@ -1337,8 +1335,8 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-1 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-1 or has an incompatible shape
-   *                                  with the source array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-1 or has an incompatible shape with the source
+   * array
    */
   public static void copyTo(int[] src, IntNdArray dst) {
     NdArrays.vectorOf(src).copyTo(dst);
@@ -1349,12 +1347,12 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-2 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-2 or has an incompatible shape
-   *                                  with the source array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-2 or has an incompatible shape with the source
+   * array
    */
   public static void copyTo(int[][] src, IntNdArray dst) {
     dst.elements(0).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(src[(int)idx[0]]).copyTo(e)
+        NdArrays.vectorOf(src[(int) idx[0]]).copyTo(e)
     );
   }
 
@@ -1363,12 +1361,12 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-3 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-3 or has an incompatible shape
-   *                                  with the source array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-3 or has an incompatible shape with the source
+   * array
    */
   public static void copyTo(int[][][] src, IntNdArray dst) {
     dst.elements(1).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]]).copyTo(e)
+        NdArrays.vectorOf(src[(int) idx[0]][(int) idx[1]]).copyTo(e)
     );
   }
 
@@ -1377,12 +1375,12 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-4 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-4 or has an incompatible shape
-   *                                  with the source array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-4 or has an incompatible shape with the source
+   * array
    */
   public static void copyTo(int[][][][] src, IntNdArray dst) {
     dst.elements(2).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]][(int)idx[2]]).copyTo(e)
+        NdArrays.vectorOf(src[(int) idx[0]][(int) idx[1]][(int) idx[2]]).copyTo(e)
     );
   }
 
@@ -1391,12 +1389,12 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-5 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-5 or has an incompatible shape
-   *                                  with the source array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-5 or has an incompatible shape with the source
+   * array
    */
   public static void copyTo(int[][][][][] src, IntNdArray dst) {
     dst.elements(3).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]]).copyTo(e)
+        NdArrays.vectorOf(src[(int) idx[0]][(int) idx[1]][(int) idx[2]][(int) idx[3]]).copyTo(e)
     );
   }
 
@@ -1405,12 +1403,12 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-6 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-6 or has an incompatible shape
-   *                                  with the source array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-6 or has an incompatible shape with the source
+   * array
    */
   public static void copyTo(int[][][][][][] src, IntNdArray dst) {
     dst.elements(4).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]][(int)idx[4]]).copyTo(e)
+        NdArrays.vectorOf(src[(int) idx[0]][(int) idx[1]][(int) idx[2]][(int) idx[3]][(int) idx[4]]).copyTo(e)
     );
   }
 
@@ -1419,8 +1417,8 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-1 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-1 or has an incompatible shape
-   *                                  with the source array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-1 or has an incompatible shape with the source
+   * array
    */
   public static void copyTo(long[] src, LongNdArray dst) {
     NdArrays.vectorOf(src).copyTo(dst);
@@ -1431,12 +1429,12 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-2 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-2 or has an incompatible shape
-   *                                  with the source array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-2 or has an incompatible shape with the source
+   * array
    */
   public static void copyTo(long[][] src, LongNdArray dst) {
     dst.elements(0).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(src[(int)idx[0]]).copyTo(e)
+        NdArrays.vectorOf(src[(int) idx[0]]).copyTo(e)
     );
   }
 
@@ -1445,12 +1443,12 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-3 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-3 or has an incompatible shape
-   *                                  with the source array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-3 or has an incompatible shape with the source
+   * array
    */
   public static void copyTo(long[][][] src, LongNdArray dst) {
     dst.elements(1).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]]).copyTo(e)
+        NdArrays.vectorOf(src[(int) idx[0]][(int) idx[1]]).copyTo(e)
     );
   }
 
@@ -1459,12 +1457,12 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-4 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-4 or has an incompatible shape
-   *                                  with the source array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-4 or has an incompatible shape with the source
+   * array
    */
   public static void copyTo(long[][][][] src, LongNdArray dst) {
     dst.elements(2).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]][(int)idx[2]]).copyTo(e)
+        NdArrays.vectorOf(src[(int) idx[0]][(int) idx[1]][(int) idx[2]]).copyTo(e)
     );
   }
 
@@ -1473,12 +1471,12 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-5 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-5 or has an incompatible shape
-   *                                  with the source array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-5 or has an incompatible shape with the source
+   * array
    */
   public static void copyTo(long[][][][][] src, LongNdArray dst) {
     dst.elements(3).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]]).copyTo(e)
+        NdArrays.vectorOf(src[(int) idx[0]][(int) idx[1]][(int) idx[2]][(int) idx[3]]).copyTo(e)
     );
   }
 
@@ -1487,12 +1485,12 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-6 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-6 or has an incompatible shape
-   *                                  with the source array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-6 or has an incompatible shape with the source
+   * array
    */
   public static void copyTo(long[][][][][][] src, LongNdArray dst) {
     dst.elements(4).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]][(int)idx[4]]).copyTo(e)
+        NdArrays.vectorOf(src[(int) idx[0]][(int) idx[1]][(int) idx[2]][(int) idx[3]][(int) idx[4]]).copyTo(e)
     );
   }
 
@@ -1501,8 +1499,8 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-1 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-1 or has an incompatible shape
-   *                                  with the source array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-1 or has an incompatible shape with the source
+   * array
    */
   public static void copyTo(float[] src, FloatNdArray dst) {
     NdArrays.vectorOf(src).copyTo(dst);
@@ -1513,12 +1511,12 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-2 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-2 or has an incompatible shape
-   *                                  with the source array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-2 or has an incompatible shape with the source
+   * array
    */
   public static void copyTo(float[][] src, FloatNdArray dst) {
     dst.elements(0).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(src[(int)idx[0]]).copyTo(e)
+        NdArrays.vectorOf(src[(int) idx[0]]).copyTo(e)
     );
   }
 
@@ -1527,12 +1525,12 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-3 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-3 or has an incompatible shape
-   *                                  with the source array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-3 or has an incompatible shape with the source
+   * array
    */
   public static void copyTo(float[][][] src, FloatNdArray dst) {
     dst.elements(1).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]]).copyTo(e)
+        NdArrays.vectorOf(src[(int) idx[0]][(int) idx[1]]).copyTo(e)
     );
   }
 
@@ -1541,12 +1539,12 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-4 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-4 or has an incompatible shape
-   *                                  with the source array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-4 or has an incompatible shape with the source
+   * array
    */
   public static void copyTo(float[][][][] src, FloatNdArray dst) {
     dst.elements(2).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]][(int)idx[2]]).copyTo(e)
+        NdArrays.vectorOf(src[(int) idx[0]][(int) idx[1]][(int) idx[2]]).copyTo(e)
     );
   }
 
@@ -1555,12 +1553,12 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-5 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-5 or has an incompatible shape
-   *                                  with the source array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-5 or has an incompatible shape with the source
+   * array
    */
   public static void copyTo(float[][][][][] src, FloatNdArray dst) {
     dst.elements(3).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]]).copyTo(e)
+        NdArrays.vectorOf(src[(int) idx[0]][(int) idx[1]][(int) idx[2]][(int) idx[3]]).copyTo(e)
     );
   }
 
@@ -1569,12 +1567,12 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-6 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-6 or has an incompatible shape
-   *                                  with the source array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-6 or has an incompatible shape with the source
+   * array
    */
   public static void copyTo(float[][][][][][] src, FloatNdArray dst) {
     dst.elements(4).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]][(int)idx[4]]).copyTo(e)
+        NdArrays.vectorOf(src[(int) idx[0]][(int) idx[1]][(int) idx[2]][(int) idx[3]][(int) idx[4]]).copyTo(e)
     );
   }
 
@@ -1583,8 +1581,8 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-1 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-1 or has an incompatible shape
-   *                                  with the source array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-1 or has an incompatible shape with the source
+   * array
    */
   public static void copyTo(double[] src, DoubleNdArray dst) {
     NdArrays.vectorOf(src).copyTo(dst);
@@ -1595,12 +1593,12 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-2 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-2 or has an incompatible shape
-   *                                  with the source array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-2 or has an incompatible shape with the source
+   * array
    */
   public static void copyTo(double[][] src, DoubleNdArray dst) {
     dst.elements(0).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(src[(int)idx[0]]).copyTo(e)
+        NdArrays.vectorOf(src[(int) idx[0]]).copyTo(e)
     );
   }
 
@@ -1609,12 +1607,12 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-3 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-3 or has an incompatible shape
-   *                                  with the source array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-3 or has an incompatible shape with the source
+   * array
    */
   public static void copyTo(double[][][] src, DoubleNdArray dst) {
     dst.elements(1).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]]).copyTo(e)
+        NdArrays.vectorOf(src[(int) idx[0]][(int) idx[1]]).copyTo(e)
     );
   }
 
@@ -1623,12 +1621,12 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-4 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-4 or has an incompatible shape
-   *                                  with the source array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-4 or has an incompatible shape with the source
+   * array
    */
   public static void copyTo(double[][][][] src, DoubleNdArray dst) {
     dst.elements(2).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]][(int)idx[2]]).copyTo(e)
+        NdArrays.vectorOf(src[(int) idx[0]][(int) idx[1]][(int) idx[2]]).copyTo(e)
     );
   }
 
@@ -1637,12 +1635,12 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-5 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-5 or has an incompatible shape
-   *                                  with the source array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-5 or has an incompatible shape with the source
+   * array
    */
   public static void copyTo(double[][][][][] src, DoubleNdArray dst) {
     dst.elements(3).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]]).copyTo(e)
+        NdArrays.vectorOf(src[(int) idx[0]][(int) idx[1]][(int) idx[2]][(int) idx[3]]).copyTo(e)
     );
   }
 
@@ -1651,12 +1649,12 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-6 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-6 or has an incompatible shape
-   *                                  with the source array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-6 or has an incompatible shape with the source
+   * array
    */
   public static void copyTo(double[][][][][][] src, DoubleNdArray dst) {
     dst.elements(4).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]][(int)idx[4]]).copyTo(e)
+        NdArrays.vectorOf(src[(int) idx[0]][(int) idx[1]][(int) idx[2]][(int) idx[3]][(int) idx[4]]).copyTo(e)
     );
   }
 
@@ -1665,8 +1663,8 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-1 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-1 or has an incompatible shape
-   *                                  with the source array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-1 or has an incompatible shape with the source
+   * array
    */
   public static void copyTo(byte[] src, ByteNdArray dst) {
     NdArrays.vectorOf(src).copyTo(dst);
@@ -1677,12 +1675,12 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-2 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-2 or has an incompatible shape
-   *                                  with the source array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-2 or has an incompatible shape with the source
+   * array
    */
   public static void copyTo(byte[][] src, ByteNdArray dst) {
     dst.elements(0).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(src[(int)idx[0]]).copyTo(e)
+        NdArrays.vectorOf(src[(int) idx[0]]).copyTo(e)
     );
   }
 
@@ -1691,12 +1689,12 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-3 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-3 or has an incompatible shape
-   *                                  with the source array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-3 or has an incompatible shape with the source
+   * array
    */
   public static void copyTo(byte[][][] src, ByteNdArray dst) {
     dst.elements(1).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]]).copyTo(e)
+        NdArrays.vectorOf(src[(int) idx[0]][(int) idx[1]]).copyTo(e)
     );
   }
 
@@ -1705,12 +1703,12 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-4 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-4 or has an incompatible shape
-   *                                  with the source array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-4 or has an incompatible shape with the source
+   * array
    */
   public static void copyTo(byte[][][][] src, ByteNdArray dst) {
     dst.elements(2).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]][(int)idx[2]]).copyTo(e)
+        NdArrays.vectorOf(src[(int) idx[0]][(int) idx[1]][(int) idx[2]]).copyTo(e)
     );
   }
 
@@ -1719,12 +1717,12 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-5 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-5 or has an incompatible shape
-   *                                  with the source array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-5 or has an incompatible shape with the source
+   * array
    */
   public static void copyTo(byte[][][][][] src, ByteNdArray dst) {
     dst.elements(3).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]]).copyTo(e)
+        NdArrays.vectorOf(src[(int) idx[0]][(int) idx[1]][(int) idx[2]][(int) idx[3]]).copyTo(e)
     );
   }
 
@@ -1733,12 +1731,12 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-6 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-6 or has an incompatible shape
-   *                                  with the source array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-6 or has an incompatible shape with the source
+   * array
    */
   public static void copyTo(byte[][][][][][] src, ByteNdArray dst) {
     dst.elements(4).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]][(int)idx[4]]).copyTo(e)
+        NdArrays.vectorOf(src[(int) idx[0]][(int) idx[1]][(int) idx[2]][(int) idx[3]][(int) idx[4]]).copyTo(e)
     );
   }
 
@@ -1747,8 +1745,8 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-1 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-1 or has an incompatible shape
-   *                                  with the source array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-1 or has an incompatible shape with the source
+   * array
    */
   public static void copyTo(short[] src, ShortNdArray dst) {
     NdArrays.vectorOf(src).copyTo(dst);
@@ -1759,12 +1757,12 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-2 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-2 or has an incompatible shape
-   *                                  with the source array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-2 or has an incompatible shape with the source
+   * array
    */
   public static void copyTo(short[][] src, ShortNdArray dst) {
     dst.elements(0).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(src[(int)idx[0]]).copyTo(e)
+        NdArrays.vectorOf(src[(int) idx[0]]).copyTo(e)
     );
   }
 
@@ -1773,12 +1771,12 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-3 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-3 or has an incompatible shape
-   *                                  with the source array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-3 or has an incompatible shape with the source
+   * array
    */
   public static void copyTo(short[][][] src, ShortNdArray dst) {
     dst.elements(1).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]]).copyTo(e)
+        NdArrays.vectorOf(src[(int) idx[0]][(int) idx[1]]).copyTo(e)
     );
   }
 
@@ -1787,12 +1785,12 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-4 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-4 or has an incompatible shape
-   *                                  with the source array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-4 or has an incompatible shape with the source
+   * array
    */
   public static void copyTo(short[][][][] src, ShortNdArray dst) {
     dst.elements(2).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]][(int)idx[2]]).copyTo(e)
+        NdArrays.vectorOf(src[(int) idx[0]][(int) idx[1]][(int) idx[2]]).copyTo(e)
     );
   }
 
@@ -1801,12 +1799,12 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-5 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-5 or has an incompatible shape
-   *                                  with the source array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-5 or has an incompatible shape with the source
+   * array
    */
   public static void copyTo(short[][][][][] src, ShortNdArray dst) {
     dst.elements(3).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]]).copyTo(e)
+        NdArrays.vectorOf(src[(int) idx[0]][(int) idx[1]][(int) idx[2]][(int) idx[3]]).copyTo(e)
     );
   }
 
@@ -1815,12 +1813,12 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-6 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-6 or has an incompatible shape
-   *                                  with the source array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-6 or has an incompatible shape with the source
+   * array
    */
   public static void copyTo(short[][][][][][] src, ShortNdArray dst) {
     dst.elements(4).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]][(int)idx[4]]).copyTo(e)
+        NdArrays.vectorOf(src[(int) idx[0]][(int) idx[1]][(int) idx[2]][(int) idx[3]][(int) idx[4]]).copyTo(e)
     );
   }
 
@@ -1829,8 +1827,8 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-1 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-1 or has an incompatible shape
-   *                                  with the source array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-1 or has an incompatible shape with the source
+   * array
    */
   public static void copyTo(boolean[] src, BooleanNdArray dst) {
     NdArrays.vectorOf(src).copyTo(dst);
@@ -1841,12 +1839,12 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-2 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-2 or has an incompatible shape
-   *                                  with the source array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-2 or has an incompatible shape with the source
+   * array
    */
   public static void copyTo(boolean[][] src, BooleanNdArray dst) {
     dst.elements(0).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(src[(int)idx[0]]).copyTo(e)
+        NdArrays.vectorOf(src[(int) idx[0]]).copyTo(e)
     );
   }
 
@@ -1855,12 +1853,12 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-3 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-3 or has an incompatible shape
-   *                                  with the source array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-3 or has an incompatible shape with the source
+   * array
    */
   public static void copyTo(boolean[][][] src, BooleanNdArray dst) {
     dst.elements(1).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]]).copyTo(e)
+        NdArrays.vectorOf(src[(int) idx[0]][(int) idx[1]]).copyTo(e)
     );
   }
 
@@ -1869,12 +1867,12 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-4 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-4 or has an incompatible shape
-   *                                  with the source array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-4 or has an incompatible shape with the source
+   * array
    */
   public static void copyTo(boolean[][][][] src, BooleanNdArray dst) {
     dst.elements(2).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]][(int)idx[2]]).copyTo(e)
+        NdArrays.vectorOf(src[(int) idx[0]][(int) idx[1]][(int) idx[2]]).copyTo(e)
     );
   }
 
@@ -1883,12 +1881,12 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-5 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-5 or has an incompatible shape
-   *                                  with the source array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-5 or has an incompatible shape with the source
+   * array
    */
   public static void copyTo(boolean[][][][][] src, BooleanNdArray dst) {
     dst.elements(3).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]]).copyTo(e)
+        NdArrays.vectorOf(src[(int) idx[0]][(int) idx[1]][(int) idx[2]][(int) idx[3]]).copyTo(e)
     );
   }
 
@@ -1897,12 +1895,12 @@ public final class StdArrays {
    *
    * @param src source array
    * @param dst destination rank-6 array
-   * @throws IllegalArgumentException if {@code dst} is not of rank-6 or has an incompatible shape
-   *                                  with the source array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-6 or has an incompatible shape with the source
+   * array
    */
   public static void copyTo(boolean[][][][][][] src, BooleanNdArray dst) {
     dst.elements(4).forEachIndexed((idx, e) ->
-        NdArrays.vectorOf(src[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]][(int)idx[4]]).copyTo(e)
+        NdArrays.vectorOf(src[(int) idx[0]][(int) idx[1]][(int) idx[2]][(int) idx[3]][(int) idx[4]]).copyTo(e)
     );
   }
 
@@ -1912,8 +1910,8 @@ public final class StdArrays {
    * @param src source array
    * @param dst destination rank-1 array
    * @param <T> data type
-   * @throws IllegalArgumentException if {@code dst} is not of rank-1 or has an incompatible shape
-   *                                  with the source array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-1 or has an incompatible shape with the source
+   * array
    */
   public static <T> void copyTo(T[] src, NdArray<T> dst) {
     NdArrays.vectorOfObjects(src).copyTo(dst);
@@ -1925,12 +1923,12 @@ public final class StdArrays {
    * @param src source array
    * @param dst destination rank-2 array
    * @param <T> data type
-   * @throws IllegalArgumentException if {@code dst} is not of rank-2 or has an incompatible shape
-   *                                  with the source array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-2 or has an incompatible shape with the source
+   * array
    */
   public static <T> void copyTo(T[][] src, NdArray<T> dst) {
     dst.elements(0).forEachIndexed((idx, e) ->
-        NdArrays.vectorOfObjects(src[(int)idx[0]]).copyTo(e)
+        NdArrays.vectorOfObjects(src[(int) idx[0]]).copyTo(e)
     );
   }
 
@@ -1940,12 +1938,12 @@ public final class StdArrays {
    * @param src source array
    * @param dst destination rank-3 array
    * @param <T> data type
-   * @throws IllegalArgumentException if {@code dst} is not of rank-3 or has an incompatible shape
-   *                                  with the source array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-3 or has an incompatible shape with the source
+   * array
    */
   public static <T> void copyTo(T[][][] src, NdArray<T> dst) {
     dst.elements(1).forEachIndexed((idx, e) ->
-        NdArrays.vectorOfObjects(src[(int)idx[0]][(int)idx[1]]).copyTo(e)
+        NdArrays.vectorOfObjects(src[(int) idx[0]][(int) idx[1]]).copyTo(e)
     );
   }
 
@@ -1955,12 +1953,12 @@ public final class StdArrays {
    * @param src source array
    * @param dst destination rank-4 array
    * @param <T> data type
-   * @throws IllegalArgumentException if {@code dst} is not of rank-4 or has an incompatible shape
-   *                                  with the source array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-4 or has an incompatible shape with the source
+   * array
    */
   public static <T> void copyTo(T[][][][] src, NdArray<T> dst) {
     dst.elements(2).forEachIndexed((idx, e) ->
-        NdArrays.vectorOfObjects(src[(int)idx[0]][(int)idx[1]][(int)idx[2]]).copyTo(e)
+        NdArrays.vectorOfObjects(src[(int) idx[0]][(int) idx[1]][(int) idx[2]]).copyTo(e)
     );
   }
 
@@ -1970,12 +1968,12 @@ public final class StdArrays {
    * @param src source array
    * @param dst destination rank-5 array
    * @param <T> data type
-   * @throws IllegalArgumentException if {@code dst} is not of rank-5 or has an incompatible shape
-   *                                  with the source array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-5 or has an incompatible shape with the source
+   * array
    */
   public static <T> void copyTo(T[][][][][] src, NdArray<T> dst) {
     dst.elements(3).forEachIndexed((idx, e) ->
-        NdArrays.vectorOfObjects(src[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]]).copyTo(e)
+        NdArrays.vectorOfObjects(src[(int) idx[0]][(int) idx[1]][(int) idx[2]][(int) idx[3]]).copyTo(e)
     );
   }
 
@@ -1985,12 +1983,12 @@ public final class StdArrays {
    * @param src source array
    * @param dst destination rank-6 array
    * @param <T> data type
-   * @throws IllegalArgumentException if {@code dst} is not of rank-6 or has an incompatible shape
-   *                                  with the source array
+   * @throws IllegalArgumentException if {@code dst} is not of rank-6 or has an incompatible shape with the source
+   * array
    */
   public static <T> void copyTo(T[][][][][][] src, NdArray<T> dst) {
     dst.elements(4).forEachIndexed((idx, e) ->
-        NdArrays.vectorOfObjects(src[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]][(int)idx[4]]).copyTo(e)
+        NdArrays.vectorOfObjects(src[(int) idx[0]][(int) idx[1]][(int) idx[2]][(int) idx[3]][(int) idx[4]]).copyTo(e)
     );
   }
 
@@ -2026,7 +2024,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(0).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int)idx[0]])
+        copyFrom(e, dst[(int) idx[0]])
     );
   }
 
@@ -2043,7 +2041,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(1).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int)idx[0]][(int)idx[1]])
+        copyFrom(e, dst[(int) idx[0]][(int) idx[1]])
     );
   }
 
@@ -2060,7 +2058,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(2).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int)idx[0]][(int)idx[1]][(int)idx[2]])
+        copyFrom(e, dst[(int) idx[0]][(int) idx[1]][(int) idx[2]])
     );
   }
 
@@ -2077,7 +2075,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(3).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]])
+        copyFrom(e, dst[(int) idx[0]][(int) idx[1]][(int) idx[2]][(int) idx[3]])
     );
   }
 
@@ -2094,7 +2092,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(4).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]][(int)idx[4]])
+        copyFrom(e, dst[(int) idx[0]][(int) idx[1]][(int) idx[2]][(int) idx[3]][(int) idx[4]])
     );
   }
 
@@ -2129,7 +2127,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(0).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int)idx[0]])
+        copyFrom(e, dst[(int) idx[0]])
     );
   }
 
@@ -2146,7 +2144,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(1).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int)idx[0]][(int)idx[1]])
+        copyFrom(e, dst[(int) idx[0]][(int) idx[1]])
     );
   }
 
@@ -2163,7 +2161,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(2).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int)idx[0]][(int)idx[1]][(int)idx[2]])
+        copyFrom(e, dst[(int) idx[0]][(int) idx[1]][(int) idx[2]])
     );
   }
 
@@ -2180,7 +2178,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(3).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]])
+        copyFrom(e, dst[(int) idx[0]][(int) idx[1]][(int) idx[2]][(int) idx[3]])
     );
   }
 
@@ -2197,7 +2195,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(4).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]][(int)idx[4]])
+        copyFrom(e, dst[(int) idx[0]][(int) idx[1]][(int) idx[2]][(int) idx[3]][(int) idx[4]])
     );
   }
 
@@ -2232,7 +2230,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(0).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int)idx[0]])
+        copyFrom(e, dst[(int) idx[0]])
     );
   }
 
@@ -2249,7 +2247,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(1).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int)idx[0]][(int)idx[1]])
+        copyFrom(e, dst[(int) idx[0]][(int) idx[1]])
     );
   }
 
@@ -2266,7 +2264,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(2).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int)idx[0]][(int)idx[1]][(int)idx[2]])
+        copyFrom(e, dst[(int) idx[0]][(int) idx[1]][(int) idx[2]])
     );
   }
 
@@ -2283,7 +2281,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(3).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]])
+        copyFrom(e, dst[(int) idx[0]][(int) idx[1]][(int) idx[2]][(int) idx[3]])
     );
   }
 
@@ -2300,7 +2298,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(4).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]][(int)idx[4]])
+        copyFrom(e, dst[(int) idx[0]][(int) idx[1]][(int) idx[2]][(int) idx[3]][(int) idx[4]])
     );
   }
 
@@ -2335,7 +2333,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(0).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int)idx[0]])
+        copyFrom(e, dst[(int) idx[0]])
     );
   }
 
@@ -2352,7 +2350,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(1).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int)idx[0]][(int)idx[1]])
+        copyFrom(e, dst[(int) idx[0]][(int) idx[1]])
     );
   }
 
@@ -2369,7 +2367,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(2).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int)idx[0]][(int)idx[1]][(int)idx[2]])
+        copyFrom(e, dst[(int) idx[0]][(int) idx[1]][(int) idx[2]])
     );
   }
 
@@ -2386,7 +2384,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(3).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]])
+        copyFrom(e, dst[(int) idx[0]][(int) idx[1]][(int) idx[2]][(int) idx[3]])
     );
   }
 
@@ -2403,7 +2401,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(4).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]][(int)idx[4]])
+        copyFrom(e, dst[(int) idx[0]][(int) idx[1]][(int) idx[2]][(int) idx[3]][(int) idx[4]])
     );
   }
 
@@ -2438,7 +2436,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(0).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int)idx[0]])
+        copyFrom(e, dst[(int) idx[0]])
     );
   }
 
@@ -2455,7 +2453,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(1).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int)idx[0]][(int)idx[1]])
+        copyFrom(e, dst[(int) idx[0]][(int) idx[1]])
     );
   }
 
@@ -2472,7 +2470,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(2).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int)idx[0]][(int)idx[1]][(int)idx[2]])
+        copyFrom(e, dst[(int) idx[0]][(int) idx[1]][(int) idx[2]])
     );
   }
 
@@ -2489,7 +2487,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(3).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]])
+        copyFrom(e, dst[(int) idx[0]][(int) idx[1]][(int) idx[2]][(int) idx[3]])
     );
   }
 
@@ -2506,7 +2504,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(4).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]][(int)idx[4]])
+        copyFrom(e, dst[(int) idx[0]][(int) idx[1]][(int) idx[2]][(int) idx[3]][(int) idx[4]])
     );
   }
 
@@ -2541,7 +2539,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(0).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int)idx[0]])
+        copyFrom(e, dst[(int) idx[0]])
     );
   }
 
@@ -2558,7 +2556,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(1).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int)idx[0]][(int)idx[1]])
+        copyFrom(e, dst[(int) idx[0]][(int) idx[1]])
     );
   }
 
@@ -2575,7 +2573,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(2).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int)idx[0]][(int)idx[1]][(int)idx[2]])
+        copyFrom(e, dst[(int) idx[0]][(int) idx[1]][(int) idx[2]])
     );
   }
 
@@ -2592,7 +2590,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(3).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]])
+        copyFrom(e, dst[(int) idx[0]][(int) idx[1]][(int) idx[2]][(int) idx[3]])
     );
   }
 
@@ -2609,7 +2607,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(4).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]][(int)idx[4]])
+        copyFrom(e, dst[(int) idx[0]][(int) idx[1]][(int) idx[2]][(int) idx[3]][(int) idx[4]])
     );
   }
 
@@ -2644,7 +2642,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(0).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int)idx[0]])
+        copyFrom(e, dst[(int) idx[0]])
     );
   }
 
@@ -2661,7 +2659,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(1).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int)idx[0]][(int)idx[1]])
+        copyFrom(e, dst[(int) idx[0]][(int) idx[1]])
     );
   }
 
@@ -2678,7 +2676,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(2).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int)idx[0]][(int)idx[1]][(int)idx[2]])
+        copyFrom(e, dst[(int) idx[0]][(int) idx[1]][(int) idx[2]])
     );
   }
 
@@ -2695,7 +2693,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(3).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]])
+        copyFrom(e, dst[(int) idx[0]][(int) idx[1]][(int) idx[2]][(int) idx[3]])
     );
   }
 
@@ -2712,7 +2710,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(4).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]][(int)idx[4]])
+        copyFrom(e, dst[(int) idx[0]][(int) idx[1]][(int) idx[2]][(int) idx[3]][(int) idx[4]])
     );
   }
 
@@ -2749,7 +2747,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(0).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int)idx[0]])
+        copyFrom(e, dst[(int) idx[0]])
     );
   }
 
@@ -2767,7 +2765,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(1).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int)idx[0]][(int)idx[1]])
+        copyFrom(e, dst[(int) idx[0]][(int) idx[1]])
     );
   }
 
@@ -2785,7 +2783,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(2).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int)idx[0]][(int)idx[1]][(int)idx[2]])
+        copyFrom(e, dst[(int) idx[0]][(int) idx[1]][(int) idx[2]])
     );
   }
 
@@ -2803,7 +2801,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(3).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]])
+        copyFrom(e, dst[(int) idx[0]][(int) idx[1]][(int) idx[2]][(int) idx[3]])
     );
   }
 
@@ -2821,7 +2819,7 @@ public final class StdArrays {
       throw new IllegalArgumentException("Array cannot be copied from NdArray of rank " + src.rank());
     }
     src.elements(4).forEachIndexed((idx, e) ->
-        copyFrom(e, dst[(int)idx[0]][(int)idx[1]][(int)idx[2]][(int)idx[3]][(int)idx[4]])
+        copyFrom(e, dst[(int) idx[0]][(int) idx[1]][(int) idx[2]][(int) idx[3]][(int) idx[4]])
     );
   }
 
@@ -3788,7 +3786,7 @@ public final class StdArrays {
     while (componentType.isArray()) {
       componentType = componentType.getComponentType();
     }
-    return (Class<T>)componentType;
+    return (Class<T>) componentType;
   }
 
   private static int[] computeArrayDims(NdArray<?> ndArray, int expectedRank) {
@@ -3798,11 +3796,12 @@ public final class StdArrays {
     }
     int[] arrayShape = new int[expectedRank];
     for (int i = 0; i < expectedRank; ++i) {
-      long dimSize = shape.size(i);
+      long dimSize = shape.get(i);
       if (dimSize > Integer.MAX_VALUE) {
-        throw new IllegalArgumentException("Dimension " + i + " is too large to fit in a standard array (" + shape.size(i) + ")");
+        throw new IllegalArgumentException(
+            "Dimension " + i + " is too large to fit in a standard array (" + shape.get(i) + ")");
       }
-      arrayShape[i] = (int)dimSize;
+      arrayShape[i] = (int) dimSize;
     }
     return arrayShape;
   }

--- a/ndarray/src/main/java/org/tensorflow/ndarray/StdArrays.java
+++ b/ndarray/src/main/java/org/tensorflow/ndarray/StdArrays.java
@@ -3800,7 +3800,7 @@ public final class StdArrays {
     for (int i = 0; i < expectedRank; ++i) {
       long dimSize = shape.get(i);
       if (dimSize > Integer.MAX_VALUE) {
-        throw new IllegalArgumentException("Dimension " + i + " is too large to fit in a standard array (" + shape.size(i) + ")");
+        throw new IllegalArgumentException("Dimension " + i + " is too large to fit in a standard array (" + shape.get(i) + ")");
       }
       arrayShape[i] = (int)dimSize;
     }

--- a/ndarray/src/main/java/org/tensorflow/ndarray/impl/dimension/DimensionalSpace.java
+++ b/ndarray/src/main/java/org/tensorflow/ndarray/impl/dimension/DimensionalSpace.java
@@ -28,7 +28,7 @@ public class DimensionalSpace {
 
     // Start from the last dimension, where all elements are continuous
     for (int i = dimensions.length - 1, elementSize = 1; i >= 0; --i) {
-      dimensions[i] = new Axis(shape.size(i), elementSize);
+      dimensions[i] = new Axis(shape.get(i), elementSize);
       elementSize *= dimensions[i].numElements();
     }
     return new DimensionalSpace(dimensions, shape);
@@ -189,7 +189,9 @@ public class DimensionalSpace {
     return position;
   }
 
-  /** Succinct description of the shape meant for debugging. */
+  /**
+   * Succinct description of the shape meant for debugging.
+   */
   @Override
   public String toString() {
     return Arrays.toString(dimensions);

--- a/ndarray/src/test/java/org/tensorflow/ndarray/NdArrayTestBase.java
+++ b/ndarray/src/test/java/org/tensorflow/ndarray/NdArrayTestBase.java
@@ -24,10 +24,10 @@ import static org.tensorflow.ndarray.index.Indices.all;
 import static org.tensorflow.ndarray.index.Indices.at;
 import static org.tensorflow.ndarray.index.Indices.even;
 import static org.tensorflow.ndarray.index.Indices.flip;
-import static org.tensorflow.ndarray.index.Indices.sliceFrom;
 import static org.tensorflow.ndarray.index.Indices.odd;
 import static org.tensorflow.ndarray.index.Indices.range;
 import static org.tensorflow.ndarray.index.Indices.seq;
+import static org.tensorflow.ndarray.index.Indices.sliceFrom;
 import static org.tensorflow.ndarray.index.Indices.sliceTo;
 
 import java.nio.BufferOverflowException;
@@ -132,15 +132,15 @@ public abstract class NdArrayTestBase<T> {
     long value = 0L;
     for (NdArray<T> matrix : matrix3d.elements(0)) {
       assertEquals(2L, matrix.shape().numDimensions());
-      assertEquals(4L, matrix.shape().size(0));
-      assertEquals(5L, matrix.shape().size(1));
+      assertEquals(4L, matrix.shape().get(0));
+      assertEquals(5L, matrix.shape().get(1));
 
       for (NdArray<T> vector : matrix.elements(0)) {
-        assertEquals(1L, vector.shape().numDimensions()) ;
-        assertEquals(5L, vector.shape().size(0));
+        assertEquals(1L, vector.shape().numDimensions());
+        assertEquals(5L, vector.shape().get(0));
 
         for (NdArray<T> scalar : vector.scalars()) {
-          assertEquals(0L, scalar.shape().numDimensions()) ;
+          assertEquals(0L, scalar.shape().numDimensions());
           scalar.setObject(valueOf(value++));
           try {
             scalar.elements(0);
@@ -162,7 +162,7 @@ public abstract class NdArrayTestBase<T> {
   @Test
   public void slices() {
     NdArray<T> matrix3d = allocate(Shape.of(5, 4, 5));
-    
+
     T val100 = valueOf(100L);
     matrix3d.setObject(val100, 1, 0, 0);
     T val101 = valueOf(101L);
@@ -318,8 +318,8 @@ public abstract class NdArrayTestBase<T> {
     NdArray<T> array4 = allocate(Shape.of(1, 2, 2));
 
     @SuppressWarnings("unchecked")
-    T[][][] values = (T[][][])(new Object[][][] {
-        { { valueOf(0L), valueOf(1L) }, { valueOf(2L), valueOf(0L) } }
+    T[][][] values = (T[][][]) (new Object[][][]{
+        {{valueOf(0L), valueOf(1L)}, {valueOf(2L), valueOf(0L)}}
     });
 
     StdArrays.copyTo(values[0], array1);

--- a/ndarray/src/test/java/org/tensorflow/ndarray/ShapeTest.java
+++ b/ndarray/src/test/java/org/tensorflow/ndarray/ShapeTest.java
@@ -16,9 +16,15 @@ limitations under the License.
 */
 package org.tensorflow.ndarray;
 
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 
 public class ShapeTest {
 
@@ -26,22 +32,22 @@ public class ShapeTest {
   public void allKnownDimensions() {
     Shape shape = Shape.of(5, 4, 5);
     assertEquals(3, shape.numDimensions());
-    assertEquals(5, shape.size(0));
-    assertEquals(4, shape.size(1));
-    assertEquals(5, shape.size(2));
+    assertEquals(5, shape.get(0));
+    assertEquals(4, shape.get(1));
+    assertEquals(5, shape.get(2));
     assertEquals(100, shape.size());
-    assertArrayEquals(new long[] {5, 4, 5}, shape.asArray());
+    assertArrayEquals(new long[]{5, 4, 5}, shape.asArray());
     try {
-      shape.size(3);
+      shape.get(3);
       fail();
     } catch (IndexOutOfBoundsException e) {
       // as expected
     }
-    assertEquals(5, shape.size(-1));
-    assertEquals(4, shape.size(-2));
-    assertEquals(5, shape.size(-3));
+    assertEquals(5, shape.get(-1));
+    assertEquals(4, shape.get(-2));
+    assertEquals(5, shape.get(-3));
     try {
-      shape.size(-4);
+      shape.get(-4);
       fail();
     } catch (IndexOutOfBoundsException e) {
       // as expected
@@ -133,7 +139,7 @@ public class ShapeTest {
     long[] internalShape = one.asArray();
     assertNotNull(internalShape);
     internalShape[0] = 42L;
-    assertEquals(2L, one.size(0));
+    assertEquals(2L, one.get(0));
   }
 
   @Test


### PR DESCRIPTION
Renames `Shape.size` to `Shape.get` and add a `toListOrNull` method.  Was part of tensorflow/java#165.