### PR TITLE
Fix bug when slicing on a segmented dimension

### DIFF
--- a/ndarray/src/main/java/org/tensorflow/ndarray/impl/dimension/DimensionalSpace.java
+++ b/ndarray/src/main/java/org/tensorflow/ndarray/impl/dimension/DimensionalSpace.java
@@ -144,7 +144,7 @@ public class DimensionalSpace {
       throw new IndexOutOfBoundsException();
     }
     Dimension[] newDimensions = Arrays.copyOfRange(dimensions, dimensionStart, dimensions.length);
-    if (segmentationIdx > dimensionStart) {
+    if (segmentationIdx >= dimensionStart) {
       return new DimensionalSpace(newDimensions, segmentationIdx - dimensionStart);
     }
     return new DimensionalSpace(newDimensions);

--- a/ndarray/src/test/java/org/tensorflow/ndarray/NdArrayTestBase.java
+++ b/ndarray/src/test/java/org/tensorflow/ndarray/NdArrayTestBase.java
@@ -34,6 +34,7 @@ import java.nio.BufferOverflowException;
 import java.nio.BufferUnderflowException;
 import org.junit.jupiter.api.Test;
 import org.tensorflow.ndarray.buffer.DataBuffer;
+import org.tensorflow.ndarray.index.Indices;
 
 public abstract class NdArrayTestBase<T> {
 
@@ -334,5 +335,27 @@ public abstract class NdArrayTestBase<T> {
     assertNotEquals(array1.hashCode(), array3.hashCode());
     assertNotEquals(array1, array4);
     assertNotEquals(array1.hashCode(), array4.hashCode());
+  }
+
+  @Test
+  public void iterateScalarsOnSegmentedElements() {
+    NdArray<T> originalTensor = allocate(Shape.of(2, 3));
+
+    originalTensor
+        .setObject(valueOf(0L), 0, 0)
+        .setObject(valueOf(1L), 0, 1)
+        .setObject(valueOf(2L), 0, 2)
+        .setObject(valueOf(3L), 1, 0)
+        .setObject(valueOf(4L), 1, 1)
+        .setObject(valueOf(5L), 1, 2);
+
+    NdArray<T> slice = originalTensor.slice(Indices.all(), Indices.sliceFrom(1));
+    assertEquals(Shape.of(2, 2), slice.shape());
+
+    slice.elements(0).forEachIndexed((eCoord, e) -> {
+      e.scalars().forEachIndexed((sCoord, s) -> {
+        assertEquals(valueOf((eCoord[0] * originalTensor.shape().get(1)) + sCoord[0] + 1), s.getObject());
+      });
+    });
   }
 }


### PR DESCRIPTION
This is a bug found by @JimClarke5 while working on the Sparse tensors. When slicing on a dimension that was segmented (i.e. which elements are no more sequential due to a previous slice), we were losing track of that information.