### PR TITLE
Allow SparseNdArray impls to be inherited

### DIFF
--- a/ndarray/src/main/java/org/tensorflow/ndarray/impl/sparse/BooleanSparseNdArray.java
+++ b/ndarray/src/main/java/org/tensorflow/ndarray/impl/sparse/BooleanSparseNdArray.java
@@ -63,6 +63,29 @@ public class BooleanSparseNdArray extends AbstractSparseNdArray<Boolean, Boolean
     implements BooleanNdArray {
 
   /**
+   * Creates a BooleanSparseNdArray
+   *
+   * @param indices A 2-D LongNdArray of shape {@code [N, ndims]}, that specifies the indices of the
+   *     elements in the sparse array that contain non-default values (elements are zero-indexed).
+   *     For example, {@code indices=[[1,3], [2,4]]} specifies that the elements with indexes of
+   *     {@code [1,3]} and {@code [2,4]} have non-default values.
+   * @param values A 1-D NdArray of Boolean type and shape {@code [N]}, which supplies the values
+   *     for each element in indices. For example, given {@code indices=[[1,3], [2,4]]}, the
+   *     parameter {@code values=[18, 3.6]} specifies that element {@code [1,3]} of the sparse
+   *     NdArray has a value of {@code 18}, and element {@code [2,4]} of the NdArray has a value of
+   *     {@code 3.6}.
+   * @param defaultValue Scalar value to set for indices not specified in {@link #getIndices()}
+   * @param dimensions the dimensional space for the dense object represented by this sparse array,
+   */
+  protected BooleanSparseNdArray(
+      LongNdArray indices,
+      BooleanNdArray values,
+      boolean defaultValue,
+      DimensionalSpace dimensions) {
+    super(indices, values, defaultValue, dimensions);
+  }
+
+  /**
    * Creates a BooleanSparseNdArray with a default value of false.
    *
    * @param indices A 2-D LongNdArray of shape {@code [N, ndims]}, that specifies the indices of the
@@ -78,29 +101,6 @@ public class BooleanSparseNdArray extends AbstractSparseNdArray<Boolean, Boolean
    */
   BooleanSparseNdArray(LongNdArray indices, BooleanNdArray values, DimensionalSpace dimensions) {
     this(indices, values, false, dimensions);
-  }
-
-  /**
-   * Creates a BooleanSparseNdArray
-   *
-   * @param indices A 2-D LongNdArray of shape {@code [N, ndims]}, that specifies the indices of the
-   *     elements in the sparse array that contain non-default values (elements are zero-indexed).
-   *     For example, {@code indices=[[1,3], [2,4]]} specifies that the elements with indexes of
-   *     {@code [1,3]} and {@code [2,4]} have non-default values.
-   * @param values A 1-D NdArray of Boolean type and shape {@code [N]}, which supplies the values
-   *     for each element in indices. For example, given {@code indices=[[1,3], [2,4]]}, the
-   *     parameter {@code values=[18, 3.6]} specifies that element {@code [1,3]} of the sparse
-   *     NdArray has a value of {@code 18}, and element {@code [2,4]} of the NdArray has a value of
-   *     {@code 3.6}.
-   * @param defaultValue Scalar value to set for indices not specified in {@link #getIndices()}
-   * @param dimensions the dimensional space for the dense object represented by this sparse array,
-   */
-  BooleanSparseNdArray(
-      LongNdArray indices,
-      BooleanNdArray values,
-      boolean defaultValue,
-      DimensionalSpace dimensions) {
-    super(indices, values, defaultValue, dimensions);
   }
 
   /**

--- a/ndarray/src/main/java/org/tensorflow/ndarray/impl/sparse/ByteSparseNdArray.java
+++ b/ndarray/src/main/java/org/tensorflow/ndarray/impl/sparse/ByteSparseNdArray.java
@@ -63,6 +63,25 @@ public class ByteSparseNdArray extends AbstractSparseNdArray<Byte, ByteNdArray>
     implements ByteNdArray {
 
   /**
+   * Creates a ByteSparseNdArray with a default value of zero.
+   *
+   * @param indices A 2-D LongNdArray of shape {@code [N, ndims]}, that specifies the indices of the
+   *     elements in the sparse array that contain non-default values (elements are zero-indexed).
+   *     For example, {@code indices=[[1,3], [2,4]]} specifies that the elements with indexes of
+   *     {@code [1,3]} and {@code [2,4]} have non-default values.
+   * @param values A 1-D NdArray of Byte type and shape {@code [N]}, which supplies the values for
+   *     each element in indices. For example, given {@code indices=[[1,3], [2,4]]}, the parameter
+   *     {@code values=[18, 3.6]} specifies that element {@code [1,3]} of the sparse NdArray has a
+   *     value of {@code 18}, and element {@code [2,4]} of the NdArray has a value of {@code 3.6}.
+   * @param defaultValue Scalar value to set for indices not specified in {@link #getIndices()}
+   * @param dimensions the dimensional space for the dense object represented by this sparse array,
+   */
+  protected ByteSparseNdArray(
+      LongNdArray indices, ByteNdArray values, byte defaultValue, DimensionalSpace dimensions) {
+    super(indices, values, defaultValue, dimensions);
+  }
+
+  /**
    * Creates a ByteSparseNdArray
    *
    * @param indices A 2-D LongNdArray of shape {@code [N, ndims]}, that specifies the indices of the
@@ -77,25 +96,6 @@ public class ByteSparseNdArray extends AbstractSparseNdArray<Byte, ByteNdArray>
    */
   ByteSparseNdArray(LongNdArray indices, ByteNdArray values, DimensionalSpace dimensions) {
     this(indices, values, (byte) 0, dimensions);
-  }
-
-  /**
-   * Creates a ByteSparseNdArray with a default value of zero.
-   *
-   * @param indices A 2-D LongNdArray of shape {@code [N, ndims]}, that specifies the indices of the
-   *     elements in the sparse array that contain non-default values (elements are zero-indexed).
-   *     For example, {@code indices=[[1,3], [2,4]]} specifies that the elements with indexes of
-   *     {@code [1,3]} and {@code [2,4]} have non-default values.
-   * @param values A 1-D NdArray of Byte type and shape {@code [N]}, which supplies the values for
-   *     each element in indices. For example, given {@code indices=[[1,3], [2,4]]}, the parameter
-   *     {@code values=[18, 3.6]} specifies that element {@code [1,3]} of the sparse NdArray has a
-   *     value of {@code 18}, and element {@code [2,4]} of the NdArray has a value of {@code 3.6}.
-   * @param defaultValue Scalar value to set for indices not specified in {@link #getIndices()}
-   * @param dimensions the dimensional space for the dense object represented by this sparse array,
-   */
-  ByteSparseNdArray(
-      LongNdArray indices, ByteNdArray values, byte defaultValue, DimensionalSpace dimensions) {
-    super(indices, values, defaultValue, dimensions);
   }
 
   /**

--- a/ndarray/src/main/java/org/tensorflow/ndarray/impl/sparse/DoubleSparseNdArray.java
+++ b/ndarray/src/main/java/org/tensorflow/ndarray/impl/sparse/DoubleSparseNdArray.java
@@ -63,6 +63,25 @@ public class DoubleSparseNdArray extends AbstractSparseNdArray<Double, DoubleNdA
     implements DoubleNdArray {
 
   /**
+   * Creates a DoubleSparseNdArray
+   *
+   * @param indices A 2-D LongNdArray of shape {@code [N, ndims]}, that specifies the indices of the
+   *     elements in the sparse array that contain non-default values (elements are zero-indexed).
+   *     For example, {@code indices=[[1,3], [2,4]]} specifies that the elements with indexes of
+   *     {@code [1,3]} and {@code [2,4]} have non-default values.
+   * @param values A 1-D DoubleNdArray of shape {@code [N]}, which supplies the values for each
+   *     element in indices. For example, given {@code indices=[[1,3], [2,4]]}, the parameter {@code
+   *     values=[18, 3.6]} specifies that element {@code [1,3]} of the sparse NdArray has a value of
+   *     {@code 18}, and element {@code [2,4]} of the NdArray has a value of {@code 3.6}.
+   * @param defaultValue Scalar value to set for indices not specified in {@link #getIndices()}
+   * @param dimensions the dimensional space for the dense object represented by this sparse array,
+   */
+  protected DoubleSparseNdArray(
+      LongNdArray indices, DoubleNdArray values, double defaultValue, DimensionalSpace dimensions) {
+    super(indices, values, defaultValue, dimensions);
+  }
+
+  /**
    * Creates a DoubleSparseNdArray with a default value of zero.
    *
    * @param indices A 2-D LongNdArray of shape {@code [N, ndims]}, that specifies the indices of the
@@ -77,25 +96,6 @@ public class DoubleSparseNdArray extends AbstractSparseNdArray<Double, DoubleNdA
    */
   DoubleSparseNdArray(LongNdArray indices, DoubleNdArray values, DimensionalSpace dimensions) {
     this(indices, values, 0d, dimensions);
-  }
-
-  /**
-   * Creates a DoubleSparseNdArray
-   *
-   * @param indices A 2-D LongNdArray of shape {@code [N, ndims]}, that specifies the indices of the
-   *     elements in the sparse array that contain non-default values (elements are zero-indexed).
-   *     For example, {@code indices=[[1,3], [2,4]]} specifies that the elements with indexes of
-   *     {@code [1,3]} and {@code [2,4]} have non-default values.
-   * @param values A 1-D DoubleNdArray of shape {@code [N]}, which supplies the values for each
-   *     element in indices. For example, given {@code indices=[[1,3], [2,4]]}, the parameter {@code
-   *     values=[18, 3.6]} specifies that element {@code [1,3]} of the sparse NdArray has a value of
-   *     {@code 18}, and element {@code [2,4]} of the NdArray has a value of {@code 3.6}.
-   * @param defaultValue Scalar value to set for indices not specified in {@link #getIndices()}
-   * @param dimensions the dimensional space for the dense object represented by this sparse array,
-   */
-  DoubleSparseNdArray(
-      LongNdArray indices, DoubleNdArray values, double defaultValue, DimensionalSpace dimensions) {
-    super(indices, values, defaultValue, dimensions);
   }
 
   /**

--- a/ndarray/src/main/java/org/tensorflow/ndarray/impl/sparse/FloatSparseNdArray.java
+++ b/ndarray/src/main/java/org/tensorflow/ndarray/impl/sparse/FloatSparseNdArray.java
@@ -63,6 +63,25 @@ public class FloatSparseNdArray extends AbstractSparseNdArray<Float, FloatNdArra
     implements FloatNdArray {
 
   /**
+   * Creates a FloatSparseNdArray
+   *
+   * @param indices A 2-D LongNdArray of shape {@code [N, ndims]}, that specifies the indices of the
+   *     elements in the sparse array that contain non-default values (elements are zero-indexed).
+   *     For example, {@code indices=[[1,3], [2,4]]} specifies that the elements with indexes of
+   *     {@code [1,3]} and {@code [2,4]} have non-default values.
+   * @param values A 1-D FloatNdArray of shape {@code [N]}, which supplies the values for each
+   *     element in indices. For example, given {@code indices=[[1,3], [2,4]]}, the parameter {@code
+   *     values=[18, 3.6]} specifies that element {@code [1,3]} of the sparse NdArray has a value of
+   *     {@code 18}, and element {@code [2,4]} of the NdArray has a value of {@code 3.6}.
+   * @param defaultValue Scalar value to set for indices not specified in {@link #getIndices()}
+   * @param dimensions the dimensional space for the dense object represented by this sparse array,
+   */
+  protected FloatSparseNdArray(
+      LongNdArray indices, FloatNdArray values, float defaultValue, DimensionalSpace dimensions) {
+    super(indices, values, defaultValue, dimensions);
+  }
+
+  /**
    * Creates a FloatSparseNdArray with a default value of zero.
    *
    * @param indices A 2-D LongNdArray of shape {@code [N, ndims]}, that specifies the indices of the
@@ -77,25 +96,6 @@ public class FloatSparseNdArray extends AbstractSparseNdArray<Float, FloatNdArra
    */
   FloatSparseNdArray(LongNdArray indices, FloatNdArray values, DimensionalSpace dimensions) {
     this(indices, values, 0f, dimensions);
-  }
-
-  /**
-   * Creates a FloatSparseNdArray
-   *
-   * @param indices A 2-D LongNdArray of shape {@code [N, ndims]}, that specifies the indices of the
-   *     elements in the sparse array that contain non-default values (elements are zero-indexed).
-   *     For example, {@code indices=[[1,3], [2,4]]} specifies that the elements with indexes of
-   *     {@code [1,3]} and {@code [2,4]} have non-default values.
-   * @param values A 1-D FloatNdArray of shape {@code [N]}, which supplies the values for each
-   *     element in indices. For example, given {@code indices=[[1,3], [2,4]]}, the parameter {@code
-   *     values=[18, 3.6]} specifies that element {@code [1,3]} of the sparse NdArray has a value of
-   *     {@code 18}, and element {@code [2,4]} of the NdArray has a value of {@code 3.6}.
-   * @param defaultValue Scalar value to set for indices not specified in {@link #getIndices()}
-   * @param dimensions the dimensional space for the dense object represented by this sparse array,
-   */
-  FloatSparseNdArray(
-      LongNdArray indices, FloatNdArray values, float defaultValue, DimensionalSpace dimensions) {
-    super(indices, values, defaultValue, dimensions);
   }
 
   /**

--- a/ndarray/src/main/java/org/tensorflow/ndarray/impl/sparse/IntSparseNdArray.java
+++ b/ndarray/src/main/java/org/tensorflow/ndarray/impl/sparse/IntSparseNdArray.java
@@ -63,6 +63,25 @@ public class IntSparseNdArray extends AbstractSparseNdArray<Integer, IntNdArray>
     implements IntNdArray {
 
   /**
+   * Creates a IntSparseNdArray
+   *
+   * @param indices A 2-D LongNdArray of shape {@code [N, ndims]}, that specifies the indices of the
+   *     elements in the sparse array that contain non-default values (elements are zero-indexed).
+   *     For example, {@code indices=[[1,3], [2,4]]} specifies that the elements with indexes of
+   *     {@code [1,3]} and {@code [2,4]} have non-default values.
+   * @param values A 1-D IntNdArray of shape {@code [N]}, which supplies the values for each element
+   *     in indices. For example, given {@code indices=[[1,3], [2,4]]}, the parameter {@code
+   *     values=[18, 3.6]} specifies that element {@code [1,3]} of the sparse NdArray has a value of
+   *     {@code 18}, and element {@code [2,4]} of the NdArray has a value of {@code 3.6}.
+   * @param defaultValue Scalar value to set for indices not specified in {@link #getIndices()}
+   * @param dimensions the dimensional space for the dense object represented by this sparse array,
+   */
+  protected IntSparseNdArray(
+      LongNdArray indices, IntNdArray values, int defaultValue, DimensionalSpace dimensions) {
+    super(indices, values, defaultValue, dimensions);
+  }
+
+  /**
    * Creates a IntSparseNdArray with a default value of zero.
    *
    * @param indices A 2-D LongNdArray of shape {@code [N, ndims]}, that specifies the indices of the
@@ -77,25 +96,6 @@ public class IntSparseNdArray extends AbstractSparseNdArray<Integer, IntNdArray>
    */
   IntSparseNdArray(LongNdArray indices, IntNdArray values, DimensionalSpace dimensions) {
     this(indices, values, 0, dimensions);
-  }
-
-  /**
-   * Creates a IntSparseNdArray
-   *
-   * @param indices A 2-D LongNdArray of shape {@code [N, ndims]}, that specifies the indices of the
-   *     elements in the sparse array that contain non-default values (elements are zero-indexed).
-   *     For example, {@code indices=[[1,3], [2,4]]} specifies that the elements with indexes of
-   *     {@code [1,3]} and {@code [2,4]} have non-default values.
-   * @param values A 1-D IntNdArray of shape {@code [N]}, which supplies the values for each element
-   *     in indices. For example, given {@code indices=[[1,3], [2,4]]}, the parameter {@code
-   *     values=[18, 3.6]} specifies that element {@code [1,3]} of the sparse NdArray has a value of
-   *     {@code 18}, and element {@code [2,4]} of the NdArray has a value of {@code 3.6}.
-   * @param defaultValue Scalar value to set for indices not specified in {@link #getIndices()}
-   * @param dimensions the dimensional space for the dense object represented by this sparse array,
-   */
-  IntSparseNdArray(
-      LongNdArray indices, IntNdArray values, int defaultValue, DimensionalSpace dimensions) {
-    super(indices, values, defaultValue, dimensions);
   }
 
   /**

--- a/ndarray/src/main/java/org/tensorflow/ndarray/impl/sparse/LongSparseNdArray.java
+++ b/ndarray/src/main/java/org/tensorflow/ndarray/impl/sparse/LongSparseNdArray.java
@@ -62,6 +62,25 @@ public class LongSparseNdArray extends AbstractSparseNdArray<Long, LongNdArray>
     implements LongNdArray {
 
   /**
+   * Creates a LongSparseNdArray
+   *
+   * @param indices A 2-D LongNdArray of shape {@code [N, ndims]}, that specifies the indices of the
+   *     elements in the sparse array that contain non-default values (elements are zero-indexed).
+   *     For example, {@code indices=[[1,3], [2,4]]} specifies that the elements with indexes of
+   *     {@code [1,3]} and {@code [2,4]} have non-default values.
+   * @param values A 1-D LongNdArray of shape {@code [N]}, which supplies the values for each
+   *     element in indices. For example, given {@code indices=[[1,3], [2,4]]}, the parameter {@code
+   *     values=[18, 3.6]} specifies that element {@code [1,3]} of the sparse NdArray has a value of
+   *     {@code 18}, and element {@code [2,4]} of the NdArray has a value of {@code 3.6}.
+   * @param defaultValue Scalar value to set for indices not specified in {@link #getIndices()}
+   * @param dimensions the dimensional space for the dense object represented by this sparse array,
+   */
+  protected LongSparseNdArray(
+      LongNdArray indices, LongNdArray values, long defaultValue, DimensionalSpace dimensions) {
+    super(indices, values, defaultValue, dimensions);
+  }
+
+  /**
    * Creates a LongSparseNdArray with a default value of zero.
    *
    * @param indices A 2-D LongNdArray of shape {@code [N, ndims]}, that specifies the indices of the
@@ -76,25 +95,6 @@ public class LongSparseNdArray extends AbstractSparseNdArray<Long, LongNdArray>
    */
   LongSparseNdArray(LongNdArray indices, LongNdArray values, DimensionalSpace dimensions) {
     this(indices, values, 0L, dimensions);
-  }
-
-  /**
-   * Creates a LongSparseNdArray
-   *
-   * @param indices A 2-D LongNdArray of shape {@code [N, ndims]}, that specifies the indices of the
-   *     elements in the sparse array that contain non-default values (elements are zero-indexed).
-   *     For example, {@code indices=[[1,3], [2,4]]} specifies that the elements with indexes of
-   *     {@code [1,3]} and {@code [2,4]} have non-default values.
-   * @param values A 1-D LongNdArray of shape {@code [N]}, which supplies the values for each
-   *     element in indices. For example, given {@code indices=[[1,3], [2,4]]}, the parameter {@code
-   *     values=[18, 3.6]} specifies that element {@code [1,3]} of the sparse NdArray has a value of
-   *     {@code 18}, and element {@code [2,4]} of the NdArray has a value of {@code 3.6}.
-   * @param defaultValue Scalar value to set for indices not specified in {@link #getIndices()}
-   * @param dimensions the dimensional space for the dense object represented by this sparse array,
-   */
-  LongSparseNdArray(
-      LongNdArray indices, LongNdArray values, long defaultValue, DimensionalSpace dimensions) {
-    super(indices, values, defaultValue, dimensions);
   }
 
   /**

--- a/ndarray/src/main/java/org/tensorflow/ndarray/impl/sparse/ShortSparseNdArray.java
+++ b/ndarray/src/main/java/org/tensorflow/ndarray/impl/sparse/ShortSparseNdArray.java
@@ -63,6 +63,25 @@ public class ShortSparseNdArray extends AbstractSparseNdArray<Short, ShortNdArra
     implements ShortNdArray {
 
   /**
+   * Creates a ShortSparseNdArray
+   *
+   * @param indices A 2-D LongNdArray of shape {@code [N, ndims]}, that specifies the indices of the
+   *     elements in the sparse array that contain non-default values (elements are zero-indexed).
+   *     For example, {@code indices=[[1,3], [2,4]]} specifies that the elements with indexes of
+   *     {@code [1,3]} and {@code [2,4]} have non-default values.
+   * @param values A 1-D ShortNdArray of shape {@code [N]}, which supplies the values for each
+   *     element in indices. For example, given {@code indices=[[1,3], [2,4]]}, the parameter {@code
+   *     values=[18, 3.6]} specifies that element {@code [1,3]} of the sparse NdArray has a value of
+   *     {@code 18}, and element {@code [2,4]} of the NdArray has a value of {@code 3.6}.
+   * @param defaultValue Scalar value to set for indices not specified in {@link #getIndices()}
+   * @param dimensions the dimensional space for the dense object represented by this sparse array,
+   */
+  protected ShortSparseNdArray(
+      LongNdArray indices, ShortNdArray values, short defaultValue, DimensionalSpace dimensions) {
+    super(indices, values, defaultValue, dimensions);
+  }
+
+  /**
    * Creates a ShortSparseNdArray with a default value of zero.
    *
    * @param indices A 2-D LongNdArray of shape {@code [N, ndims]}, that specifies the indices of the
@@ -77,25 +96,6 @@ public class ShortSparseNdArray extends AbstractSparseNdArray<Short, ShortNdArra
    */
   ShortSparseNdArray(LongNdArray indices, ShortNdArray values, DimensionalSpace dimensions) {
     this(indices, values, (short) 0, dimensions);
-  }
-
-  /**
-   * Creates a ShortSparseNdArray
-   *
-   * @param indices A 2-D LongNdArray of shape {@code [N, ndims]}, that specifies the indices of the
-   *     elements in the sparse array that contain non-default values (elements are zero-indexed).
-   *     For example, {@code indices=[[1,3], [2,4]]} specifies that the elements with indexes of
-   *     {@code [1,3]} and {@code [2,4]} have non-default values.
-   * @param values A 1-D ShortNdArray of shape {@code [N]}, which supplies the values for each
-   *     element in indices. For example, given {@code indices=[[1,3], [2,4]]}, the parameter {@code
-   *     values=[18, 3.6]} specifies that element {@code [1,3]} of the sparse NdArray has a value of
-   *     {@code 18}, and element {@code [2,4]} of the NdArray has a value of {@code 3.6}.
-   * @param defaultValue Scalar value to set for indices not specified in {@link #getIndices()}
-   * @param dimensions the dimensional space for the dense object represented by this sparse array,
-   */
-  ShortSparseNdArray(
-      LongNdArray indices, ShortNdArray values, short defaultValue, DimensionalSpace dimensions) {
-    super(indices, values, defaultValue, dimensions);
   }
 
   /**

--- a/ndarray/src/main/java/org/tensorflow/ndarray/impl/sparse/SparseNdArray.java
+++ b/ndarray/src/main/java/org/tensorflow/ndarray/impl/sparse/SparseNdArray.java
@@ -63,6 +63,27 @@ public class SparseNdArray<T, U extends NdArray<T>> extends AbstractSparseNdArra
   private final Class<T> type;
 
   /**
+   * Creates a SparseNdArray
+   *
+   * @param indices A 2-D LongNdArray of shape {@code [N, ndims]}, that specifies the indices of the
+   *     elements in the sparse array that contain non-default values (elements are zero-indexed).
+   *     For example, {@code indices=[[1,3], [2,4]]} specifies that the elements with indexes of
+   *     {@code [1,3]} and {@code [2,4]} have non-default values.
+   * @param values A 1-D NdArray of Boolean type and shape {@code [N]}, which supplies the values
+   *     for each element in indices. For example, given {@code indices=[[1,3], [2,4]]}, the
+   *     parameter {@code values=[18, 3.6]} specifies that element {@code [1,3]} of the sparse
+   *     NdArray has a value of {@code 18}, and element {@code [2,4]} of the NdArray has a value of
+   *     {@code 3.6}.
+   * @param defaultValue Scalar value to set for indices not specified in {@link #getIndices()}
+   * @param dimensions the dimensional space for the dense object represented by this sparse array,
+   */
+  protected SparseNdArray(
+      Class<T> type, LongNdArray indices, U values, T defaultValue, DimensionalSpace dimensions) {
+    super(indices, values, defaultValue, dimensions);
+    this.type = type;
+  }
+
+  /**
    * Creates a SparseNdArray with a default value of null.
    *
    * @param indices A 2-D LongNdArray of shape {@code [N, ndims]}, that specifies the indices of the
@@ -78,27 +99,6 @@ public class SparseNdArray<T, U extends NdArray<T>> extends AbstractSparseNdArra
    */
   SparseNdArray(Class<T> type, LongNdArray indices, U values, DimensionalSpace dimensions) {
     this(type, indices, values, null, dimensions);
-  }
-
-  /**
-   * Creates a SparseNdArray
-   *
-   * @param indices A 2-D LongNdArray of shape {@code [N, ndims]}, that specifies the indices of the
-   *     elements in the sparse array that contain non-default values (elements are zero-indexed).
-   *     For example, {@code indices=[[1,3], [2,4]]} specifies that the elements with indexes of
-   *     {@code [1,3]} and {@code [2,4]} have non-default values.
-   * @param values A 1-D NdArray of Boolean type and shape {@code [N]}, which supplies the values
-   *     for each element in indices. For example, given {@code indices=[[1,3], [2,4]]}, the
-   *     parameter {@code values=[18, 3.6]} specifies that element {@code [1,3]} of the sparse
-   *     NdArray has a value of {@code 18}, and element {@code [2,4]} of the NdArray has a value of
-   *     {@code 3.6}.
-   * @param defaultValue Scalar value to set for indices not specified in {@link #getIndices()}
-   * @param dimensions the dimensional space for the dense object represented by this sparse array,
-   */
-  SparseNdArray(
-      Class<T> type, LongNdArray indices, U values, T defaultValue, DimensionalSpace dimensions) {
-    super(indices, values, defaultValue, dimensions);
-    this.type = type;
   }
 
   /**


### PR DESCRIPTION
Just unlocks `SparseNdArray` implementations constructor to be extended by sub-classes (requires for TensorFlow sparse tensor support)