### PR TITLE
Build on JDK11 by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: Configure Java
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: '11'
       - name: Checkout repository
         uses: actions/checkout@v1
       - name: Build project

--- a/ndarray/pom.xml
+++ b/ndarray/pom.xml
@@ -75,7 +75,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.22.2</version>
+        <version>3.0.0-M5</version>
         <configuration>
           <forkCount>1</forkCount>
           <reuseForks>false</reuseForks>
@@ -83,7 +83,22 @@
           <includes>
             <include>**/*Test.java</include>
           </includes>
+          <useModulePath>false</useModulePath>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-testCompile</id>
+            <configuration>
+              <compilerArgs>
+                <arg>--add-modules=java.desktop</arg> <!-- For AWT usage in benchmarks -->
+              </compilerArgs>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/ndarray/pom.xml
+++ b/ndarray/pom.xml
@@ -79,7 +79,7 @@
         <configuration>
           <forkCount>1</forkCount>
           <reuseForks>false</reuseForks>
-          <argLine>-Xmx2G -XX:MaxPermSize=256m</argLine>
+          <argLine>-Xmx2G</argLine>
           <includes>
             <include>**/*Test.java</include>
           </includes>

--- a/ndarray/src/main/java/module-info.java
+++ b/ndarray/src/main/java/module-info.java
@@ -1,0 +1,37 @@
+/*
+ Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ =======================================================================
+ */
+module org.tensorflow.ndarray {
+  exports org.tensorflow.ndarray;
+  exports org.tensorflow.ndarray.buffer;
+  exports org.tensorflow.ndarray.buffer.layout;
+  exports org.tensorflow.ndarray.index;
+
+  // Expose all implementions of our interfaces, so consumers can write custom
+  // implementations easily by extending from them
+  exports org.tensorflow.ndarray.impl.buffer.adapter;
+  exports org.tensorflow.ndarray.impl.buffer.layout;
+  exports org.tensorflow.ndarray.impl.buffer.misc;
+  exports org.tensorflow.ndarray.impl.buffer.nio;
+  exports org.tensorflow.ndarray.impl.buffer.raw;
+  exports org.tensorflow.ndarray.impl.dense;
+  exports org.tensorflow.ndarray.impl.dimension;
+  exports org.tensorflow.ndarray.impl.sequence;
+  exports org.tensorflow.ndarray.impl.sparse;
+  exports org.tensorflow.ndarray.impl.sparse.slice;
+
+  requires jdk.unsupported; // required by raw buffer implementations using Unsafe
+}

--- a/ndarray/src/main/java/org/tensorflow/ndarray/impl/buffer/raw/UnsafeReference.java
+++ b/ndarray/src/main/java/org/tensorflow/ndarray/impl/buffer/raw/UnsafeReference.java
@@ -36,29 +36,39 @@ final class UnsafeReference {
       theUnsafe.setAccessible(true);
       Object instance = theUnsafe.get(null);
       if (instance.getClass() == clazz) {
-        // Validate that this Unsafe instance exposes all methods we need
-        clazz.getDeclaredMethod("getByte", Object.class, long.class);
-        clazz.getDeclaredMethod("putByte", Object.class, long.class, byte.class);
-        clazz.getDeclaredMethod("getShort", Object.class, long.class);
-        clazz.getDeclaredMethod("putShort", Object.class, long.class, short.class);
-        clazz.getDeclaredMethod("getInt", Object.class, long.class);
-        clazz.getDeclaredMethod("putInt", Object.class, long.class, int.class);
-        clazz.getDeclaredMethod("getLong", Object.class, long.class);
-        clazz.getDeclaredMethod("putLong", Object.class, long.class, long.class);
-        clazz.getDeclaredMethod("getFloat", Object.class, long.class);
-        clazz.getDeclaredMethod("putFloat", Object.class, long.class, float.class);
-        clazz.getDeclaredMethod("getDouble", Object.class, long.class);
-        clazz.getDeclaredMethod("putDouble", Object.class, long.class, double.class);
-        clazz.getDeclaredMethod("getBoolean", Object.class, long.class);
-        clazz.getDeclaredMethod("putBoolean", Object.class, long.class, boolean.class);
-        clazz.getDeclaredMethod("copyMemory", Object.class, long.class, Object.class, long.class, long.class);
-        clazz.getDeclaredMethod("arrayBaseOffset", Class.class);
-        clazz.getDeclaredMethod("arrayIndexScale", Class.class);
+        checkMethod(clazz, "getByte", Object.class, long.class);
+        checkMethod(clazz, "putByte", Object.class, long.class, byte.class);
+        checkMethod(clazz, "getShort", Object.class, long.class);
+        checkMethod(clazz, "putShort", Object.class, long.class, short.class);
+        checkMethod(clazz, "getInt", Object.class, long.class);
+        checkMethod(clazz, "putInt", Object.class, long.class, int.class);
+        checkMethod(clazz, "getLong", Object.class, long.class);
+        checkMethod(clazz, "putLong", Object.class, long.class, long.class);
+        checkMethod(clazz, "getFloat", Object.class, long.class);
+        checkMethod(clazz, "putFloat", Object.class, long.class, float.class);
+        checkMethod(clazz, "getDouble", Object.class, long.class);
+        checkMethod(clazz, "putDouble", Object.class, long.class, double.class);
+        checkMethod(clazz, "getBoolean", Object.class, long.class);
+        checkMethod(clazz, "putBoolean", Object.class, long.class, boolean.class);
+        checkMethod(clazz, "copyMemory", Object.class, long.class, Object.class, long.class, long.class);
+        checkMethod(clazz, "arrayBaseOffset", Class.class);
+        checkMethod(clazz, "arrayIndexScale", Class.class);
+
         unsafe = (Unsafe) instance;
       }
     } catch (ClassNotFoundException | NoSuchMethodException | NoSuchFieldException | SecurityException | IllegalAccessException | ClassCastException ex) {
       // Do nothing, keep unsafe as null
     }
     UNSAFE = unsafe;
+  }
+
+  /**
+   * Validate that this Unsafe instance exposes this method
+   *
+   * ErrorProne does not like that we do nothing with the returned method... but there is nothing to do with it, so disable the check
+   */
+  @SuppressWarnings("ReturnValueIgnored")
+  private static void checkMethod(Class<?> unsafeClass, String methodName, Class<?>... parameterTypes) throws NoSuchMethodException {
+    unsafeClass.getDeclaredMethod(methodName, parameterTypes);
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -167,7 +167,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-compiler-plugin</artifactId>
-            <version>3.8.0</version>
+            <version>3.9.0</version>
             <configuration>
               <showWarnings>true</showWarnings>
               <fork>true</fork> <!-- Required for JDK16+ -->

--- a/pom.xml
+++ b/pom.xml
@@ -34,12 +34,12 @@
 
   <properties>
     <project.build.sourceEncoding>ASCII</project.build.sourceEncoding>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
     <junit.version>5.6.2</junit.version>
     <jmh.version>1.21</jmh.version>
     <versions-plugin.version>2.7</versions-plugin.version>
-    <errorprone.version>2.6.0</errorprone.version>
+    <errorprone.version>2.10.0</errorprone.version>
     <gpg.skip>true</gpg.skip>
   </properties>
 
@@ -141,11 +141,11 @@
     </profile>
 
     <profile>
-      <id>jdk11</id>
+      <id>jdk17</id>
       <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
-        <maven.compiler.release>11</maven.compiler.release>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.release>17</maven.compiler.release>
       </properties>
     </profile>
 
@@ -156,8 +156,6 @@
     <profile>
       <id>lint</id>
       <activation>
-        <!-- activate lint checks only on JDK1.9+ (required by Error Prone) -->
-        <jdk>(1.9,)</jdk>
         <!-- custom property to disable link checks on command line (enabled by default) -->
         <property>
           <name>!lint.skip</name>


### PR DESCRIPTION
As discussed and voted by SIG JVM, the minimal supported JDK version for distributed artifacts has moved from Java8 to Java11. Java17 build is also supported by the activation of the `jdk17` Maven profile.