### PR TITLE
Adding toString to AbstractDenseNdArray and AbstractSparseNdArray

### DIFF
--- a/ndarray/src/main/java/org/tensorflow/ndarray/impl/dense/AbstractDenseNdArray.java
+++ b/ndarray/src/main/java/org/tensorflow/ndarray/impl/dense/AbstractDenseNdArray.java
@@ -132,6 +132,15 @@ public abstract class AbstractDenseNdArray<T, U extends NdArray<T>> extends Abst
     return buffer().equals(other.buffer());
   }
 
+  /**
+   * A String showing the type and shape of this dense ndarray.
+   * @return A string containing the type and shape.
+   */
+  @Override
+  public String toString() {
+    return this.getClass().getSimpleName() + "(shape=" + this.shape() + ")";
+  }
+
   protected AbstractDenseNdArray(DimensionalSpace dimensions) {
     super(dimensions);
   }

--- a/ndarray/src/main/java/org/tensorflow/ndarray/impl/sparse/AbstractSparseNdArray.java
+++ b/ndarray/src/main/java/org/tensorflow/ndarray/impl/sparse/AbstractSparseNdArray.java
@@ -403,6 +403,26 @@ public abstract class AbstractSparseNdArray<T, U extends NdArray<T>> extends Abs
   }
 
   /**
+   * A String showing the type, default value, number of elements and
+   * the dense shape of this sparse ndarray.
+   * @return A string containing the type, default value, number of elements and shape.
+   */
+  @Override
+  public String toString() {
+    long numElements = values == null ? 0 : values.size();
+    String strDefault;
+    if (defaultValue == null) {
+      strDefault = "<null>";
+    } else if (defaultValue instanceof Number){
+      strDefault = defaultValue.toString();
+    } else {
+      strDefault = "'" + defaultValue + "'";
+    }
+    return this.getClass().getSimpleName() + "(defaultValue=" + strDefault
+            + ",numElements=" + numElements + ",shape=" + this.shape() + ")";
+  }
+
+  /**
    * Performs a binary search on the indices array to locate the index of the specified coordinates.
    * The indices array must be sorted by coordinates, row major.
    *

--- a/ndarray/src/main/java/org/tensorflow/ndarray/impl/sparse/AbstractSparseNdArray.java
+++ b/ndarray/src/main/java/org/tensorflow/ndarray/impl/sparse/AbstractSparseNdArray.java
@@ -413,13 +413,13 @@ public abstract class AbstractSparseNdArray<T, U extends NdArray<T>> extends Abs
     String strDefault;
     if (defaultValue == null) {
       strDefault = "<null>";
-    } else if (defaultValue instanceof Number){
+    } else if (defaultValue instanceof Number) {
       strDefault = defaultValue.toString();
     } else {
       strDefault = "'" + defaultValue + "'";
     }
     return this.getClass().getSimpleName() + "(defaultValue=" + strDefault
-            + ",numElements=" + numElements + ",shape=" + this.shape() + ")";
+            + ", numElements=" + numElements + ", shape=" + this.shape() + ")";
   }
 
   /**

--- a/ndarray/src/main/java/org/tensorflow/ndarray/impl/sparse/SparseNdArray.java
+++ b/ndarray/src/main/java/org/tensorflow/ndarray/impl/sparse/SparseNdArray.java
@@ -394,4 +394,25 @@ public class SparseNdArray<T, U extends NdArray<T>> extends AbstractSparseNdArra
   public Class<T> getType() {
     return type;
   }
+
+  /**
+   * A String showing the type, default value, number of elements and
+   * the dense shape of this sparse ndarray.
+   * @return A string containing the type, default value, number of elements and shape.
+   */
+  @Override
+  public String toString() {
+    long numElements = getValues() == null ? 0 : getValues().size();
+    String strDefault;
+    T defaultVal = getDefaultValue();
+    if (defaultVal == null) {
+      strDefault = "<null>";
+    } else if (defaultVal instanceof Number){
+      strDefault = defaultVal.toString();
+    } else {
+      strDefault = "'" + defaultVal + "'";
+    }
+    return this.getClass().getSimpleName() + "(type="+type.getSimpleName()+",defaultValue=" + strDefault
+            + ",numElements=" + numElements + ",shape=" + this.shape() + ")";
+  }
 }

--- a/ndarray/src/main/java/org/tensorflow/ndarray/impl/sparse/SparseNdArray.java
+++ b/ndarray/src/main/java/org/tensorflow/ndarray/impl/sparse/SparseNdArray.java
@@ -407,12 +407,12 @@ public class SparseNdArray<T, U extends NdArray<T>> extends AbstractSparseNdArra
     T defaultVal = getDefaultValue();
     if (defaultVal == null) {
       strDefault = "<null>";
-    } else if (defaultVal instanceof Number){
+    } else if (defaultVal instanceof Number) {
       strDefault = defaultVal.toString();
     } else {
       strDefault = "'" + defaultVal + "'";
     }
-    return this.getClass().getSimpleName() + "(type="+type.getSimpleName()+",defaultValue=" + strDefault
-            + ",numElements=" + numElements + ",shape=" + this.shape() + ")";
+    return this.getClass().getSimpleName() + "(type="+type.getSimpleName()+", defaultValue=" + strDefault
+            + ", numElements=" + numElements + ", shape=" + this.shape() + ")";
   }
 }

--- a/ndarray/src/test/java/org/tensorflow/ndarray/impl/dense/BooleanDenseNdArrayTest.java
+++ b/ndarray/src/test/java/org/tensorflow/ndarray/impl/dense/BooleanDenseNdArrayTest.java
@@ -16,6 +16,8 @@
  */
 package org.tensorflow.ndarray.impl.dense;
 
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.tensorflow.ndarray.Shape;
 import org.tensorflow.ndarray.buffer.DataBuffer;
 import org.tensorflow.ndarray.buffer.DataBuffers;
@@ -31,5 +33,13 @@ public class BooleanDenseNdArrayTest extends BooleanNdArrayTestBase {
 
   @Override protected DataBuffer<Boolean> allocateBuffer(long size) {
     return DataBuffers.ofBooleans(size);
+  }
+
+  @Test
+  public void testToString() {
+    BooleanNdArray matrix3d = allocate(Shape.of(5, 4, 5));
+    Assertions.assertEquals("BooleanDenseNdArray(shape=[5, 4, 5])",matrix3d.toString());
+    BooleanNdArray scalar = allocate(Shape.of());
+    Assertions.assertEquals("BooleanDenseNdArray(shape=[])",scalar.toString());
   }
 }

--- a/ndarray/src/test/java/org/tensorflow/ndarray/impl/dense/DoubleDenseNdArrayTest.java
+++ b/ndarray/src/test/java/org/tensorflow/ndarray/impl/dense/DoubleDenseNdArrayTest.java
@@ -16,6 +16,8 @@
  */
 package org.tensorflow.ndarray.impl.dense;
 
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.tensorflow.ndarray.Shape;
 import org.tensorflow.ndarray.buffer.DataBuffer;
 import org.tensorflow.ndarray.buffer.DataBuffers;
@@ -31,5 +33,15 @@ public class DoubleDenseNdArrayTest extends DoubleNdArrayTestBase {
 
   @Override protected DataBuffer<Double> allocateBuffer(long size) {
     return DataBuffers.ofDoubles(size);
+  }
+
+  @Test
+  public void testToString() {
+    DoubleNdArray matrix3d = allocate(Shape.of(5, 4, 5));
+    Assertions.assertEquals("DoubleDenseNdArray(shape=[5, 4, 5])",matrix3d.toString());
+    DoubleNdArray vector = allocate(Shape.of(5));
+    Assertions.assertEquals("DoubleDenseNdArray(shape=[5])",vector.toString());
+    DoubleNdArray scalar = allocate(Shape.of());
+    Assertions.assertEquals("DoubleDenseNdArray(shape=[])",scalar.toString());
   }
 }

--- a/ndarray/src/test/java/org/tensorflow/ndarray/impl/sparse/DoubleSparseNdArrayTest.java
+++ b/ndarray/src/test/java/org/tensorflow/ndarray/impl/sparse/DoubleSparseNdArrayTest.java
@@ -310,8 +310,8 @@ class DoubleSparseNdArrayTest {
     DoubleSparseNdArray instance =
             DoubleSparseNdArray.create(DimensionalSpace.create(ndArray.shape()));
     instance.fromDense(ndArray);
-    Assertions.assertEquals("DoubleSparseNdArray(defaultValue=0.0,numElements=2,shape=[3, 4])",instance.toString());
+    Assertions.assertEquals("DoubleSparseNdArray(defaultValue=0.0, numElements=2, shape=[3, 4])",instance.toString());
     DoubleSparseNdArray empty = DoubleSparseNdArray.create(DimensionalSpace.create(Shape.of(5)));
-    Assertions.assertEquals("DoubleSparseNdArray(defaultValue=0.0,numElements=0,shape=[5])",empty.toString());
+    Assertions.assertEquals("DoubleSparseNdArray(defaultValue=0.0, numElements=0, shape=[5])",empty.toString());
   }
 }

--- a/ndarray/src/test/java/org/tensorflow/ndarray/impl/sparse/DoubleSparseNdArrayTest.java
+++ b/ndarray/src/test/java/org/tensorflow/ndarray/impl/sparse/DoubleSparseNdArrayTest.java
@@ -1,5 +1,6 @@
 package org.tensorflow.ndarray.impl.sparse;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.tensorflow.ndarray.DoubleNdArray;
 import org.tensorflow.ndarray.LongNdArray;
@@ -301,5 +302,16 @@ class DoubleSparseNdArrayTest {
                 l.scalars()
                     .forEachIndexed(
                         (lidx, f) -> assertEquals(expected[i.getAndIncrement()], f.getDouble())));
+  }
+
+  @Test
+  public void testToString() {
+    DoubleNdArray ndArray = StdArrays.ndCopyOf(dense2DArray);
+    DoubleSparseNdArray instance =
+            DoubleSparseNdArray.create(DimensionalSpace.create(ndArray.shape()));
+    instance.fromDense(ndArray);
+    Assertions.assertEquals("DoubleSparseNdArray(defaultValue=0.0,numElements=2,shape=[3, 4])",instance.toString());
+    DoubleSparseNdArray empty = DoubleSparseNdArray.create(DimensionalSpace.create(Shape.of(5)));
+    Assertions.assertEquals("DoubleSparseNdArray(defaultValue=0.0,numElements=0,shape=[5])",empty.toString());
   }
 }

--- a/ndarray/src/test/java/org/tensorflow/ndarray/impl/sparse/StringSparseNdArrayTest.java
+++ b/ndarray/src/test/java/org/tensorflow/ndarray/impl/sparse/StringSparseNdArrayTest.java
@@ -14,6 +14,7 @@ limitations under the License.
 =======================================================================*/
 package org.tensorflow.ndarray.impl.sparse;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.tensorflow.ndarray.LongNdArray;
 import org.tensorflow.ndarray.NdArray;
@@ -337,5 +338,15 @@ public class StringSparseNdArrayTest {
     assertEquals(1L, dArray.size());
     assertNotNull(dArray.getObject());
     assertEquals("a default", dArray.getObject());
+  }
+
+  @Test
+  public void testToString() {
+    SparseNdArray<String, NdArray<String>> instance =
+            new SparseNdArray<>(String.class, indices, values, DimensionalSpace.create(shape));
+    Assertions.assertEquals("SparseNdArray(defaultValue=<null>,numElements=2,shape=[3, 4])",instance.toString());
+    instance = new SparseNdArray<>(
+                    String.class, indices, values, "a default", DimensionalSpace.create(shape));
+    Assertions.assertEquals("SparseNdArray(defaultValue='a default',numElements=2,shape=[3, 4])",instance.toString());
   }
 }

--- a/ndarray/src/test/java/org/tensorflow/ndarray/impl/sparse/StringSparseNdArrayTest.java
+++ b/ndarray/src/test/java/org/tensorflow/ndarray/impl/sparse/StringSparseNdArrayTest.java
@@ -344,9 +344,9 @@ public class StringSparseNdArrayTest {
   public void testToString() {
     SparseNdArray<String, NdArray<String>> instance =
             new SparseNdArray<>(String.class, indices, values, DimensionalSpace.create(shape));
-    Assertions.assertEquals("SparseNdArray(defaultValue=<null>,numElements=2,shape=[3, 4])",instance.toString());
+    Assertions.assertEquals("SparseNdArray(type=String,defaultValue=<null>,numElements=2,shape=[3, 4])",instance.toString());
     instance = new SparseNdArray<>(
                     String.class, indices, values, "a default", DimensionalSpace.create(shape));
-    Assertions.assertEquals("SparseNdArray(defaultValue='a default',numElements=2,shape=[3, 4])",instance.toString());
+    Assertions.assertEquals("SparseNdArray(type=String,defaultValue='a default',numElements=2,shape=[3, 4])",instance.toString());
   }
 }

--- a/ndarray/src/test/java/org/tensorflow/ndarray/impl/sparse/StringSparseNdArrayTest.java
+++ b/ndarray/src/test/java/org/tensorflow/ndarray/impl/sparse/StringSparseNdArrayTest.java
@@ -344,9 +344,9 @@ public class StringSparseNdArrayTest {
   public void testToString() {
     SparseNdArray<String, NdArray<String>> instance =
             new SparseNdArray<>(String.class, indices, values, DimensionalSpace.create(shape));
-    Assertions.assertEquals("SparseNdArray(type=String,defaultValue=<null>,numElements=2,shape=[3, 4])",instance.toString());
+    Assertions.assertEquals("SparseNdArray(type=String, defaultValue=<null>, numElements=2, shape=[3, 4])",instance.toString());
     instance = new SparseNdArray<>(
                     String.class, indices, values, "a default", DimensionalSpace.create(shape));
-    Assertions.assertEquals("SparseNdArray(type=String,defaultValue='a default',numElements=2,shape=[3, 4])",instance.toString());
+    Assertions.assertEquals("SparseNdArray(type=String, defaultValue='a default', numElements=2, shape=[3, 4])",instance.toString());
   }
 }


### PR DESCRIPTION
This adds a simple toString to `AbstractDenseNdArray` and `AbstractSparseNdArray` which pulls in the concrete class name. The dense one includes the shape, the sparse one includes the default value, the number of non-sparse elements and the dense shape. `DenseNdArray` doesn't display its type, but `SparseNdArray` does. All the other concrete classes have their type in their name so it's redundant for them and they just display the class name. For `DenseNdArray` I wasn't sure if it was possible to create a completely empty ndarray and so I'm not quite sure how to get the type.

I added a few small tests, I can roll them out to all the instances if you think it's necessary.