### PR TITLE
Rename read/write to copyTo/From

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ IntNdArray vector = matrix3d.get(0, 1);
 assertEquals(1, vector.rank());
 
 // Rewriting the values of the vector using a primitive array
-vector.write(new int[] { 7, 8 });
+vector.copyFrom(DataBuffers.of(new int[] { 7, 8 }));
 assertEquals(7, matrix3d.getInt(0, 1, 0));
 assertEquals(8, matrix3d.getInt(0, 1, 1));
 

--- a/ndarray/src/main/java/org/tensorflow/ndarray/BooleanNdArray.java
+++ b/ndarray/src/main/java/org/tensorflow/ndarray/BooleanNdArray.java
@@ -100,12 +100,12 @@ public interface BooleanNdArray extends NdArray<Boolean> {
   BooleanNdArray copyTo(NdArray<Boolean> dst);
 
   @Override
-  BooleanNdArray read(DataBuffer<Boolean> dst);
+  BooleanNdArray copyTo(DataBuffer<Boolean> dst);
 
-  BooleanNdArray read(BooleanDataBuffer dst);
+  BooleanNdArray copyTo(BooleanDataBuffer dst);
 
   @Override
-  BooleanNdArray write(DataBuffer<Boolean> src);
+  BooleanNdArray copyFrom(DataBuffer<Boolean> src);
 
-  BooleanNdArray write(BooleanDataBuffer src);
+  BooleanNdArray copyFrom(BooleanDataBuffer src);
 }

--- a/ndarray/src/main/java/org/tensorflow/ndarray/ByteNdArray.java
+++ b/ndarray/src/main/java/org/tensorflow/ndarray/ByteNdArray.java
@@ -100,12 +100,12 @@ public interface ByteNdArray extends NdArray<Byte> {
   ByteNdArray copyTo(NdArray<Byte> dst);
 
   @Override
-  ByteNdArray read(DataBuffer<Byte> dst);
+  ByteNdArray copyTo(DataBuffer<Byte> dst);
 
-  ByteNdArray read(ByteDataBuffer dst);
+  ByteNdArray copyTo(ByteDataBuffer dst);
 
   @Override
-  ByteNdArray write(DataBuffer<Byte> src);
+  ByteNdArray copyFrom(DataBuffer<Byte> src);
 
-  ByteNdArray write(ByteDataBuffer src);
+  ByteNdArray copyFrom(ByteDataBuffer src);
 }

--- a/ndarray/src/main/java/org/tensorflow/ndarray/DoubleNdArray.java
+++ b/ndarray/src/main/java/org/tensorflow/ndarray/DoubleNdArray.java
@@ -115,12 +115,12 @@ public interface DoubleNdArray extends NdArray<Double> {
   DoubleNdArray copyTo(NdArray<Double> dst);
 
   @Override
-  DoubleNdArray read(DataBuffer<Double> dst);
+  DoubleNdArray copyTo(DataBuffer<Double> dst);
 
-  DoubleNdArray read(DoubleDataBuffer dst);
+  DoubleNdArray copyTo(DoubleDataBuffer dst);
 
   @Override
-  DoubleNdArray write(DataBuffer<Double> src);
+  DoubleNdArray copyFrom(DataBuffer<Double> src);
 
-  DoubleNdArray write(DoubleDataBuffer src);
+  DoubleNdArray copyFrom(DoubleDataBuffer src);
 }

--- a/ndarray/src/main/java/org/tensorflow/ndarray/FloatNdArray.java
+++ b/ndarray/src/main/java/org/tensorflow/ndarray/FloatNdArray.java
@@ -100,12 +100,12 @@ public interface FloatNdArray extends NdArray<Float> {
   FloatNdArray copyTo(NdArray<Float> dst);
 
   @Override
-  FloatNdArray read(DataBuffer<Float> dst);
+  FloatNdArray copyTo(DataBuffer<Float> dst);
 
-  FloatNdArray read(FloatDataBuffer dst);
+  FloatNdArray copyTo(FloatDataBuffer dst);
 
   @Override
-  FloatNdArray write(DataBuffer<Float> src);
+  FloatNdArray copyFrom(DataBuffer<Float> src);
 
-  FloatNdArray write(FloatDataBuffer src);
+  FloatNdArray copyFrom(FloatDataBuffer src);
 }

--- a/ndarray/src/main/java/org/tensorflow/ndarray/IntNdArray.java
+++ b/ndarray/src/main/java/org/tensorflow/ndarray/IntNdArray.java
@@ -115,12 +115,12 @@ public interface IntNdArray extends NdArray<Integer> {
   IntNdArray copyTo(NdArray<Integer> dst);
 
   @Override
-  IntNdArray read(DataBuffer<Integer> dst);
+  IntNdArray copyTo(DataBuffer<Integer> dst);
 
-  IntNdArray read(IntDataBuffer dst);
+  IntNdArray copyTo(IntDataBuffer dst);
 
   @Override
-  IntNdArray write(DataBuffer<Integer> src);
+  IntNdArray copyFrom(DataBuffer<Integer> src);
 
-  IntNdArray write(IntDataBuffer src);
+  IntNdArray copyFrom(IntDataBuffer src);
 }

--- a/ndarray/src/main/java/org/tensorflow/ndarray/LongNdArray.java
+++ b/ndarray/src/main/java/org/tensorflow/ndarray/LongNdArray.java
@@ -115,12 +115,12 @@ public interface LongNdArray extends NdArray<Long> {
   LongNdArray copyTo(NdArray<Long> dst);
 
   @Override
-  LongNdArray read(DataBuffer<Long> dst);
+  LongNdArray copyTo(DataBuffer<Long> dst);
 
-  LongNdArray read(LongDataBuffer dst);
+  LongNdArray copyTo(LongDataBuffer dst);
 
   @Override
-  LongNdArray write(DataBuffer<Long> src);
+  LongNdArray copyFrom(DataBuffer<Long> src);
 
-  LongNdArray write(LongDataBuffer src);
+  LongNdArray copyFrom(LongDataBuffer src);
 }

--- a/ndarray/src/main/java/org/tensorflow/ndarray/NdArray.java
+++ b/ndarray/src/main/java/org/tensorflow/ndarray/NdArray.java
@@ -285,25 +285,29 @@ public interface NdArray<T> extends Shaped {
   NdArray<T> copyTo(NdArray<T> dst);
 
   /**
-   * Read the content of this N-dimensional array into the destination buffer.
+   * Copy the content of this N-dimensional array into the destination buffer.
    *
    * <p>The size of the buffer must be equal or greater to the {@link #size()} of this
    * array, or an exception is thrown. After the copy, content of the buffer and of the array can be
    * altered independently, without affecting each other.
+   *
+   * <p><i>Note: this method was previously named `read(DataBuffer<T>)`, which led to confusion.</i>
    *
    * @param dst the destination buffer
    * @return this array
    * @throws java.nio.BufferOverflowException if the buffer cannot hold the content of this array
    * @see DataBuffer#size()
    */
-  NdArray<T> read(DataBuffer<T> dst);
+  NdArray<T> copyTo(DataBuffer<T> dst);
 
   /**
-   * Write the content of this N-dimensional array from the source buffer.
+   * Copy the content of the source buffer into this N-dimensional array.
    *
    * <p>The size of the buffer must be equal or greater to the {@link #size()} of this
    * array, or an exception is thrown. After the copy, content of the buffer and of the array can be
    * altered independently, without affecting each other.
+   *
+   * <p><i>Note: this method was previously named `write(DataBuffer<T>)`, which led to confusion.</i>
    *
    * @param src the source buffer
    * @return this array
@@ -311,7 +315,7 @@ public interface NdArray<T> extends Shaped {
    * into this array
    * @see DataBuffer#size()
    */
-  NdArray<T> write(DataBuffer<T> src);
+  NdArray<T> copyFrom(DataBuffer<T> src);
 
   /**
    * Checks equality between n-dimensional arrays.

--- a/ndarray/src/main/java/org/tensorflow/ndarray/NdArray.java
+++ b/ndarray/src/main/java/org/tensorflow/ndarray/NdArray.java
@@ -291,7 +291,8 @@ public interface NdArray<T> extends Shaped {
    * array, or an exception is thrown. After the copy, content of the buffer and of the array can be
    * altered independently, without affecting each other.
    *
-   * <p><i>Note: this method was previously named `read(DataBuffer<T>)`, which led to confusion.</i>
+   * <p><i>Note: in version 0.4.0 and earlier, this method was named {@code read(DataBuffer<T>)}. It has been renamed to
+   * explicitly indicate the direction of the data flow to avoid confusion.</i>
    *
    * @param dst the destination buffer
    * @return this array
@@ -307,7 +308,8 @@ public interface NdArray<T> extends Shaped {
    * array, or an exception is thrown. After the copy, content of the buffer and of the array can be
    * altered independently, without affecting each other.
    *
-   * <p><i>Note: this method was previously named `write(DataBuffer<T>)`, which led to confusion.</i>
+   * <p><i>Note: in version 0.4.0 and earlier, this method was named {@code write(DataBuffer<T>)}. It has been renamed to
+   * explicitly indicate the direction of the data flow to avoid confusion.</i>
    *
    * @param src the source buffer
    * @return this array

--- a/ndarray/src/main/java/org/tensorflow/ndarray/ShortNdArray.java
+++ b/ndarray/src/main/java/org/tensorflow/ndarray/ShortNdArray.java
@@ -100,12 +100,12 @@ public interface ShortNdArray extends NdArray<Short> {
   ShortNdArray copyTo(NdArray<Short> dst);
 
   @Override
-  ShortNdArray read(DataBuffer<Short> dst);
+  ShortNdArray copyTo(DataBuffer<Short> dst);
 
-  ShortNdArray read(ShortDataBuffer dst);
+  ShortNdArray copyTo(ShortDataBuffer dst);
 
   @Override
-  ShortNdArray write(DataBuffer<Short> src);
+  ShortNdArray copyFrom(DataBuffer<Short> src);
 
-  ShortNdArray write(ShortDataBuffer src);
+  ShortNdArray copyFrom(ShortDataBuffer src);
 }

--- a/ndarray/src/main/java/org/tensorflow/ndarray/StdArrays.java
+++ b/ndarray/src/main/java/org/tensorflow/ndarray/StdArrays.java
@@ -2010,7 +2010,7 @@ public final class StdArrays {
     if (src.size() > dst.length) {
       throw new ArrayIndexOutOfBoundsException(String.valueOf(src.size()) + " > " + dst.length);
     }
-    src.read(DataBuffers.of(dst, false, false));
+    src.copyTo(DataBuffers.of(dst, false, false));
   }
 
   /**
@@ -2113,7 +2113,7 @@ public final class StdArrays {
     if (src.size() > dst.length) {
       throw new ArrayIndexOutOfBoundsException(String.valueOf(src.size()) + " > " + dst.length);
     }
-    src.read(DataBuffers.of(dst, false, false));
+    src.copyTo(DataBuffers.of(dst, false, false));
   }
 
   /**
@@ -2216,7 +2216,7 @@ public final class StdArrays {
     if (src.size() > dst.length) {
       throw new ArrayIndexOutOfBoundsException(String.valueOf(src.size()) + " > " + dst.length);
     }
-    src.read(DataBuffers.of(dst, false, false));
+    src.copyTo(DataBuffers.of(dst, false, false));
   }
 
   /**
@@ -2319,7 +2319,7 @@ public final class StdArrays {
     if (src.size() > dst.length) {
       throw new ArrayIndexOutOfBoundsException(String.valueOf(src.size()) + " > " + dst.length);
     }
-    src.read(DataBuffers.of(dst, false, false));
+    src.copyTo(DataBuffers.of(dst, false, false));
   }
 
   /**
@@ -2422,7 +2422,7 @@ public final class StdArrays {
     if (src.size() > dst.length) {
       throw new ArrayIndexOutOfBoundsException(String.valueOf(src.size()) + " > " + dst.length);
     }
-    src.read(DataBuffers.of(dst, false, false));
+    src.copyTo(DataBuffers.of(dst, false, false));
   }
 
   /**
@@ -2525,7 +2525,7 @@ public final class StdArrays {
     if (src.size() > dst.length) {
       throw new ArrayIndexOutOfBoundsException(String.valueOf(src.size()) + " > " + dst.length);
     }
-    src.read(DataBuffers.of(dst, false, false));
+    src.copyTo(DataBuffers.of(dst, false, false));
   }
 
   /**
@@ -2628,7 +2628,7 @@ public final class StdArrays {
     if (src.size() > dst.length) {
       throw new ArrayIndexOutOfBoundsException(String.valueOf(src.size()) + " > " + dst.length);
     }
-    src.read(DataBuffers.of(dst, false, false));
+    src.copyTo(DataBuffers.of(dst, false, false));
   }
 
   /**
@@ -2732,7 +2732,7 @@ public final class StdArrays {
     if (src.size() > dst.length) {
       throw new ArrayIndexOutOfBoundsException(String.valueOf(src.size()) + " > " + dst.length);
     }
-    src.read(DataBuffers.of(dst, false, false));
+    src.copyTo(DataBuffers.of(dst, false, false));
   }
 
   /**

--- a/ndarray/src/main/java/org/tensorflow/ndarray/impl/Validator.java
+++ b/ndarray/src/main/java/org/tensorflow/ndarray/impl/Validator.java
@@ -30,13 +30,13 @@ public class Validator {
     }
   }
 
-  public static void readToBufferArgs(NdArray<?> ndArray, DataBuffer<?> dst) {
+  public static void copyToBufferArgs(NdArray<?> ndArray, DataBuffer<?> dst) {
     if (dst.size() < ndArray.size()) {
       throw new BufferOverflowException();
     }
   }
 
-  public static void writeFromBufferArgs(NdArray<?> ndArray, DataBuffer<?> src) {
+  public static void copyFromBufferArgs(NdArray<?> ndArray, DataBuffer<?> src) {
     if (src.size() < ndArray.size()) {
       throw new BufferUnderflowException();
     }

--- a/ndarray/src/main/java/org/tensorflow/ndarray/impl/dense/AbstractDenseNdArray.java
+++ b/ndarray/src/main/java/org/tensorflow/ndarray/impl/dense/AbstractDenseNdArray.java
@@ -101,15 +101,15 @@ public abstract class AbstractDenseNdArray<T, U extends NdArray<T>> extends Abst
   }
 
   @Override
-  public U read(DataBuffer<T> dst) {
-    Validator.readToBufferArgs(this, dst);
+  public U copyTo(DataBuffer<T> dst) {
+    Validator.copyToBufferArgs(this, dst);
     DataTransfer.execute(buffer(), dimensions(), dst, DataTransfer::ofValue);
     return (U)this;
   }
 
   @Override
-  public U write(DataBuffer<T> src) {
-    Validator.writeFromBufferArgs(this, src);
+  public U copyFrom(DataBuffer<T> src) {
+    Validator.copyFromBufferArgs(this, src);
     DataTransfer.execute(src, buffer(), dimensions(), DataTransfer::ofValue);
     return (U)this;
   }

--- a/ndarray/src/main/java/org/tensorflow/ndarray/impl/dense/BooleanDenseNdArray.java
+++ b/ndarray/src/main/java/org/tensorflow/ndarray/impl/dense/BooleanDenseNdArray.java
@@ -55,15 +55,15 @@ public class BooleanDenseNdArray extends AbstractDenseNdArray<Boolean, BooleanNd
   }
 
   @Override
-  public BooleanNdArray read(BooleanDataBuffer dst) {
-    Validator.readToBufferArgs(this, dst);
+  public BooleanNdArray copyTo(BooleanDataBuffer dst) {
+    Validator.copyToBufferArgs(this, dst);
     DataTransfer.execute(buffer, dimensions(), dst, DataTransfer::ofBoolean);
     return this;
   }
 
   @Override
-  public BooleanNdArray write(BooleanDataBuffer src) {
-    Validator.writeFromBufferArgs(this, src);
+  public BooleanNdArray copyFrom(BooleanDataBuffer src) {
+    Validator.copyFromBufferArgs(this, src);
     DataTransfer.execute(src, buffer, dimensions(), DataTransfer::ofBoolean);
     return this;
   }

--- a/ndarray/src/main/java/org/tensorflow/ndarray/impl/dense/ByteDenseNdArray.java
+++ b/ndarray/src/main/java/org/tensorflow/ndarray/impl/dense/ByteDenseNdArray.java
@@ -55,15 +55,15 @@ public class ByteDenseNdArray extends AbstractDenseNdArray<Byte, ByteNdArray>
   }
 
   @Override
-  public ByteNdArray read(ByteDataBuffer dst) {
-    Validator.readToBufferArgs(this, dst);
+  public ByteNdArray copyTo(ByteDataBuffer dst) {
+    Validator.copyToBufferArgs(this, dst);
     DataTransfer.execute(buffer, dimensions(), dst, DataTransfer::ofByte);
     return this;
   }
 
   @Override
-  public ByteNdArray write(ByteDataBuffer src) {
-    Validator.writeFromBufferArgs(this, src);
+  public ByteNdArray copyFrom(ByteDataBuffer src) {
+    Validator.copyFromBufferArgs(this, src);
     DataTransfer.execute(src, buffer, dimensions(), DataTransfer::ofByte);
     return this;
   }

--- a/ndarray/src/main/java/org/tensorflow/ndarray/impl/dense/DoubleDenseNdArray.java
+++ b/ndarray/src/main/java/org/tensorflow/ndarray/impl/dense/DoubleDenseNdArray.java
@@ -55,15 +55,15 @@ public class DoubleDenseNdArray extends AbstractDenseNdArray<Double, DoubleNdArr
   }
 
   @Override
-  public DoubleNdArray read(DoubleDataBuffer dst) {
-    Validator.readToBufferArgs(this, dst);
+  public DoubleNdArray copyTo(DoubleDataBuffer dst) {
+    Validator.copyToBufferArgs(this, dst);
     DataTransfer.execute(buffer, dimensions(), dst, DataTransfer::ofDouble);
     return this;
   }
 
   @Override
-  public DoubleNdArray write(DoubleDataBuffer src) {
-    Validator.writeFromBufferArgs(this, src);
+  public DoubleNdArray copyFrom(DoubleDataBuffer src) {
+    Validator.copyFromBufferArgs(this, src);
     DataTransfer.execute(src, buffer, dimensions(), DataTransfer::ofDouble);
     return this;
   }

--- a/ndarray/src/main/java/org/tensorflow/ndarray/impl/dense/FloatDenseNdArray.java
+++ b/ndarray/src/main/java/org/tensorflow/ndarray/impl/dense/FloatDenseNdArray.java
@@ -55,15 +55,15 @@ public class FloatDenseNdArray extends AbstractDenseNdArray<Float, FloatNdArray>
   }
 
   @Override
-  public FloatNdArray read(FloatDataBuffer dst) {
-    Validator.readToBufferArgs(this, dst);
+  public FloatNdArray copyTo(FloatDataBuffer dst) {
+    Validator.copyToBufferArgs(this, dst);
     DataTransfer.execute(buffer, dimensions(), dst, DataTransfer::ofFloat);
     return this;
   }
 
   @Override
-  public FloatNdArray write(FloatDataBuffer src) {
-    Validator.writeFromBufferArgs(this, src);
+  public FloatNdArray copyFrom(FloatDataBuffer src) {
+    Validator.copyFromBufferArgs(this, src);
     DataTransfer.execute(src, buffer, dimensions(), DataTransfer::ofFloat);
     return this;
   }

--- a/ndarray/src/main/java/org/tensorflow/ndarray/impl/dense/IntDenseNdArray.java
+++ b/ndarray/src/main/java/org/tensorflow/ndarray/impl/dense/IntDenseNdArray.java
@@ -55,15 +55,15 @@ public class IntDenseNdArray extends AbstractDenseNdArray<Integer, IntNdArray>
   }
 
   @Override
-  public IntNdArray read(IntDataBuffer dst) {
-    Validator.readToBufferArgs(this, dst);
+  public IntNdArray copyTo(IntDataBuffer dst) {
+    Validator.copyToBufferArgs(this, dst);
     DataTransfer.execute(buffer, dimensions(), dst, DataTransfer::ofInt);
     return this;
   }
 
   @Override
-  public IntNdArray write(IntDataBuffer src) {
-    Validator.writeFromBufferArgs(this, src);
+  public IntNdArray copyFrom(IntDataBuffer src) {
+    Validator.copyFromBufferArgs(this, src);
     DataTransfer.execute(src, buffer, dimensions(), DataTransfer::ofInt);
     return this;
   }

--- a/ndarray/src/main/java/org/tensorflow/ndarray/impl/dense/LongDenseNdArray.java
+++ b/ndarray/src/main/java/org/tensorflow/ndarray/impl/dense/LongDenseNdArray.java
@@ -55,15 +55,15 @@ public class LongDenseNdArray extends AbstractDenseNdArray<Long, LongNdArray>
   }
 
   @Override
-  public LongNdArray read(LongDataBuffer dst) {
-    Validator.readToBufferArgs(this, dst);
+  public LongNdArray copyTo(LongDataBuffer dst) {
+    Validator.copyToBufferArgs(this, dst);
     DataTransfer.execute(buffer, dimensions(), dst, DataTransfer::ofLong);
     return this;
   }
 
   @Override
-  public LongNdArray write(LongDataBuffer src) {
-    Validator.writeFromBufferArgs(this, src);
+  public LongNdArray copyFrom(LongDataBuffer src) {
+    Validator.copyFromBufferArgs(this, src);
     DataTransfer.execute(src, buffer, dimensions(), DataTransfer::ofLong);
     return this;
   }

--- a/ndarray/src/main/java/org/tensorflow/ndarray/impl/dense/ShortDenseNdArray.java
+++ b/ndarray/src/main/java/org/tensorflow/ndarray/impl/dense/ShortDenseNdArray.java
@@ -55,15 +55,15 @@ public class ShortDenseNdArray extends AbstractDenseNdArray<Short, ShortNdArray>
   }
 
   @Override
-  public ShortNdArray read(ShortDataBuffer dst) {
-    Validator.readToBufferArgs(this, dst);
+  public ShortNdArray copyTo(ShortDataBuffer dst) {
+    Validator.copyToBufferArgs(this, dst);
     DataTransfer.execute(buffer, dimensions(), dst, DataTransfer::ofShort);
     return this;
   }
 
   @Override
-  public ShortNdArray write(ShortDataBuffer src) {
-    Validator.writeFromBufferArgs(this, src);
+  public ShortNdArray copyFrom(ShortDataBuffer src) {
+    Validator.copyFromBufferArgs(this, src);
     DataTransfer.execute(src, buffer, dimensions(), DataTransfer::ofShort);
     return this;
   }

--- a/ndarray/src/main/java/org/tensorflow/ndarray/impl/sparse/BooleanSparseNdArray.java
+++ b/ndarray/src/main/java/org/tensorflow/ndarray/impl/sparse/BooleanSparseNdArray.java
@@ -124,7 +124,7 @@ public class BooleanSparseNdArray extends AbstractSparseNdArray<Boolean, Boolean
       BooleanDataBuffer dataBuffer, boolean defaultValue, DimensionalSpace dimensions) {
     super(defaultValue, dimensions);
     // use write to set up the indices and values
-    write(dataBuffer);
+    copyFrom(dataBuffer);
   }
 
   /**
@@ -266,7 +266,7 @@ public class BooleanSparseNdArray extends AbstractSparseNdArray<Boolean, Boolean
    */
   public static BooleanSparseNdArray create(BooleanNdArray src) {
     BooleanDataBuffer buffer = DataBuffers.ofBooleans(src.size());
-    src.read(buffer);
+    src.copyTo(buffer);
     return new BooleanSparseNdArray(buffer, DimensionalSpace.create(src.shape()));
   }
   /**
@@ -278,7 +278,7 @@ public class BooleanSparseNdArray extends AbstractSparseNdArray<Boolean, Boolean
    */
   public static BooleanSparseNdArray create(BooleanNdArray src, boolean defaultValue) {
     BooleanDataBuffer buffer = DataBuffers.ofBooleans(src.size());
-    src.read(buffer);
+    src.copyTo(buffer);
     return new BooleanSparseNdArray(buffer, defaultValue, DimensionalSpace.create(src.shape()));
   }
 
@@ -318,13 +318,13 @@ public class BooleanSparseNdArray extends AbstractSparseNdArray<Boolean, Boolean
 
   /** {@inheritDoc} */
   @Override
-  public BooleanNdArray read(DataBuffer<Boolean> dst) {
-    return read((BooleanDataBuffer) dst);
+  public BooleanNdArray copyTo(DataBuffer<Boolean> dst) {
+    return copyTo((BooleanDataBuffer) dst);
   }
 
   /** {@inheritDoc} */
   @Override
-  public BooleanNdArray read(BooleanDataBuffer dst) {
+  public BooleanNdArray copyTo(BooleanDataBuffer dst) {
     // set the values in buf to the default, then overwrite with indices/values
     Boolean[] defaults = new Boolean[(int) shape().size()];
     Arrays.fill(defaults, getDefaultValue());
@@ -344,7 +344,7 @@ public class BooleanSparseNdArray extends AbstractSparseNdArray<Boolean, Boolean
 
   /** {@inheritDoc} */
   @Override
-  public BooleanNdArray write(BooleanDataBuffer src) {
+  public BooleanNdArray copyFrom(BooleanDataBuffer src) {
     List<long[]> indices = new ArrayList<>();
     List<Boolean> values = new ArrayList<>();
 
@@ -368,8 +368,8 @@ public class BooleanSparseNdArray extends AbstractSparseNdArray<Boolean, Boolean
 
   /** {@inheritDoc} */
   @Override
-  public BooleanNdArray write(DataBuffer<Boolean> src) {
-    return write((BooleanDataBuffer) src);
+  public BooleanNdArray copyFrom(DataBuffer<Boolean> src) {
+    return copyFrom((BooleanDataBuffer) src);
   }
 
   /**
@@ -379,7 +379,7 @@ public class BooleanSparseNdArray extends AbstractSparseNdArray<Boolean, Boolean
    */
   public BooleanNdArray toDense() {
     BooleanDataBuffer dataBuffer = DataBuffers.ofBooleans(shape().size());
-    read(dataBuffer);
+    copyTo(dataBuffer);
     return NdArrays.wrap(shape(), dataBuffer);
   }
 
@@ -391,8 +391,8 @@ public class BooleanSparseNdArray extends AbstractSparseNdArray<Boolean, Boolean
    */
   public BooleanNdArray fromDense(BooleanNdArray src) {
     BooleanDataBuffer buffer = DataBuffers.ofBooleans(src.size());
-    src.read(buffer);
-    write(buffer);
+    src.copyTo(buffer);
+    copyFrom(buffer);
     return this;
   }
 

--- a/ndarray/src/main/java/org/tensorflow/ndarray/impl/sparse/ByteSparseNdArray.java
+++ b/ndarray/src/main/java/org/tensorflow/ndarray/impl/sparse/ByteSparseNdArray.java
@@ -118,7 +118,7 @@ public class ByteSparseNdArray extends AbstractSparseNdArray<Byte, ByteNdArray>
   ByteSparseNdArray(ByteDataBuffer dataBuffer, byte defaultValue, DimensionalSpace dimensions) {
     super(defaultValue, dimensions);
     // use write to set up the indices and values
-    write(dataBuffer);
+    copyFrom(dataBuffer);
   }
 
   /**
@@ -255,7 +255,7 @@ public class ByteSparseNdArray extends AbstractSparseNdArray<Byte, ByteNdArray>
    */
   public static ByteSparseNdArray create(ByteNdArray src) {
     ByteDataBuffer buffer = DataBuffers.ofBytes(src.size());
-    src.read(buffer);
+    src.copyTo(buffer);
     return new ByteSparseNdArray(buffer, DimensionalSpace.create(src.shape()));
   }
 
@@ -268,7 +268,7 @@ public class ByteSparseNdArray extends AbstractSparseNdArray<Byte, ByteNdArray>
    */
   public static ByteSparseNdArray create(ByteNdArray src, byte defaultValue) {
     ByteDataBuffer buffer = DataBuffers.ofBytes(src.size());
-    src.read(buffer);
+    src.copyTo(buffer);
     return new ByteSparseNdArray(buffer, defaultValue, DimensionalSpace.create(src.shape()));
   }
 
@@ -302,13 +302,13 @@ public class ByteSparseNdArray extends AbstractSparseNdArray<Byte, ByteNdArray>
 
   /** {@inheritDoc} */
   @Override
-  public ByteNdArray read(DataBuffer<Byte> dst) {
-    return read((ByteDataBuffer) dst);
+  public ByteNdArray copyTo(DataBuffer<Byte> dst) {
+    return copyTo((ByteDataBuffer) dst);
   }
 
   /** {@inheritDoc} */
   @Override
-  public ByteNdArray read(ByteDataBuffer dst) {
+  public ByteNdArray copyTo(ByteDataBuffer dst) {
     // set the values in buf to the default, then overwrite with indices/values
     Byte[] defaults = new Byte[(int) shape().size()];
     Arrays.fill(defaults, getDefaultValue());
@@ -328,7 +328,7 @@ public class ByteSparseNdArray extends AbstractSparseNdArray<Byte, ByteNdArray>
 
   /** {@inheritDoc} */
   @Override
-  public ByteNdArray write(ByteDataBuffer src) {
+  public ByteNdArray copyFrom(ByteDataBuffer src) {
     List<long[]> indices = new ArrayList<>();
     List<Byte> values = new ArrayList<>();
 
@@ -352,8 +352,8 @@ public class ByteSparseNdArray extends AbstractSparseNdArray<Byte, ByteNdArray>
 
   /** {@inheritDoc} */
   @Override
-  public ByteNdArray write(DataBuffer<Byte> src) {
-    return write((ByteDataBuffer) src);
+  public ByteNdArray copyFrom(DataBuffer<Byte> src) {
+    return copyFrom((ByteDataBuffer) src);
   }
 
   /**
@@ -363,7 +363,7 @@ public class ByteSparseNdArray extends AbstractSparseNdArray<Byte, ByteNdArray>
    */
   public ByteNdArray toDense() {
     ByteDataBuffer dataBuffer = DataBuffers.ofBytes(shape().size());
-    read(dataBuffer);
+    copyTo(dataBuffer);
     return NdArrays.wrap(shape(), dataBuffer);
   }
 
@@ -375,8 +375,8 @@ public class ByteSparseNdArray extends AbstractSparseNdArray<Byte, ByteNdArray>
    */
   public ByteNdArray fromDense(ByteNdArray src) {
     ByteDataBuffer buffer = DataBuffers.ofBytes(src.size());
-    src.read(buffer);
-    write(buffer);
+    src.copyTo(buffer);
+    copyFrom(buffer);
     return this;
   }
 

--- a/ndarray/src/main/java/org/tensorflow/ndarray/impl/sparse/DoubleSparseNdArray.java
+++ b/ndarray/src/main/java/org/tensorflow/ndarray/impl/sparse/DoubleSparseNdArray.java
@@ -118,7 +118,7 @@ public class DoubleSparseNdArray extends AbstractSparseNdArray<Double, DoubleNdA
       DoubleDataBuffer dataBuffer, double defaultValue, DimensionalSpace dimensions) {
     super(defaultValue, dimensions);
     // use write to set up the indices and values
-    write(dataBuffer);
+    copyFrom(dataBuffer);
   }
 
   /**
@@ -257,7 +257,7 @@ public class DoubleSparseNdArray extends AbstractSparseNdArray<Double, DoubleNdA
    */
   public static DoubleSparseNdArray create(DoubleNdArray src) {
     DoubleDataBuffer buffer = DataBuffers.ofDoubles(src.size());
-    src.read(buffer);
+    src.copyTo(buffer);
     return new DoubleSparseNdArray(buffer, DimensionalSpace.create(src.shape()));
   }
   /**
@@ -269,7 +269,7 @@ public class DoubleSparseNdArray extends AbstractSparseNdArray<Double, DoubleNdA
    */
   public static DoubleSparseNdArray create(DoubleNdArray src, double defaultValue) {
     DoubleDataBuffer buffer = DataBuffers.ofDoubles(src.size());
-    src.read(buffer);
+    src.copyTo(buffer);
     return new DoubleSparseNdArray(buffer, defaultValue, DimensionalSpace.create(src.shape()));
   }
 
@@ -303,13 +303,13 @@ public class DoubleSparseNdArray extends AbstractSparseNdArray<Double, DoubleNdA
 
   /** {@inheritDoc} */
   @Override
-  public DoubleNdArray read(DataBuffer<Double> dst) {
-    return read((DoubleDataBuffer) dst);
+  public DoubleNdArray copyTo(DataBuffer<Double> dst) {
+    return copyTo((DoubleDataBuffer) dst);
   }
 
   /** {@inheritDoc} */
   @Override
-  public DoubleNdArray read(DoubleDataBuffer dst) {
+  public DoubleNdArray copyTo(DoubleDataBuffer dst) {
     // set buf to the default values, then overwrite with the indices/values.
     Double[] defaults = new Double[(int) shape().size()];
     Arrays.fill(defaults, getDefaultValue());
@@ -329,7 +329,7 @@ public class DoubleSparseNdArray extends AbstractSparseNdArray<Double, DoubleNdA
 
   /** {@inheritDoc} */
   @Override
-  public DoubleNdArray write(DoubleDataBuffer src) {
+  public DoubleNdArray copyFrom(DoubleDataBuffer src) {
     List<long[]> indices = new ArrayList<>();
     List<Double> values = new ArrayList<>();
 
@@ -353,8 +353,8 @@ public class DoubleSparseNdArray extends AbstractSparseNdArray<Double, DoubleNdA
 
   /** {@inheritDoc} */
   @Override
-  public DoubleNdArray write(DataBuffer<Double> src) {
-    return write((DoubleDataBuffer) src);
+  public DoubleNdArray copyFrom(DataBuffer<Double> src) {
+    return copyFrom((DoubleDataBuffer) src);
   }
 
   /**
@@ -364,7 +364,7 @@ public class DoubleSparseNdArray extends AbstractSparseNdArray<Double, DoubleNdA
    */
   public DoubleNdArray toDense() {
     DoubleDataBuffer dataBuffer = DataBuffers.ofDoubles(shape().size());
-    read(dataBuffer);
+    copyTo(dataBuffer);
     return NdArrays.wrap(shape(), dataBuffer);
   }
 
@@ -376,8 +376,8 @@ public class DoubleSparseNdArray extends AbstractSparseNdArray<Double, DoubleNdA
    */
   public DoubleNdArray fromDense(DoubleNdArray src) {
     DoubleDataBuffer buffer = DataBuffers.ofDoubles(src.size());
-    src.read(buffer);
-    write(buffer);
+    src.copyTo(buffer);
+    copyFrom(buffer);
     return this;
   }
 

--- a/ndarray/src/main/java/org/tensorflow/ndarray/impl/sparse/FloatSparseNdArray.java
+++ b/ndarray/src/main/java/org/tensorflow/ndarray/impl/sparse/FloatSparseNdArray.java
@@ -118,7 +118,7 @@ public class FloatSparseNdArray extends AbstractSparseNdArray<Float, FloatNdArra
   FloatSparseNdArray(FloatDataBuffer dataBuffer, float defaultValue, DimensionalSpace dimensions) {
     super(defaultValue, dimensions);
     // use write to set up the indices and values
-    write(dataBuffer);
+    copyFrom(dataBuffer);
   }
 
   /**
@@ -255,7 +255,7 @@ public class FloatSparseNdArray extends AbstractSparseNdArray<Float, FloatNdArra
    */
   public static FloatSparseNdArray create(FloatNdArray src) {
     FloatDataBuffer buffer = DataBuffers.ofFloats(src.size());
-    src.read(buffer);
+    src.copyTo(buffer);
     return new FloatSparseNdArray(buffer, DimensionalSpace.create(src.shape()));
   }
   /**
@@ -267,7 +267,7 @@ public class FloatSparseNdArray extends AbstractSparseNdArray<Float, FloatNdArra
    */
   public static FloatSparseNdArray create(FloatNdArray src, float defaultValue) {
     FloatDataBuffer buffer = DataBuffers.ofFloats(src.size());
-    src.read(buffer);
+    src.copyTo(buffer);
     return new FloatSparseNdArray(buffer, defaultValue, DimensionalSpace.create(src.shape()));
   }
 
@@ -301,13 +301,13 @@ public class FloatSparseNdArray extends AbstractSparseNdArray<Float, FloatNdArra
 
   /** {@inheritDoc} */
   @Override
-  public FloatNdArray read(DataBuffer<Float> dst) {
-    return read((FloatDataBuffer) dst);
+  public FloatNdArray copyTo(DataBuffer<Float> dst) {
+    return copyTo((FloatDataBuffer) dst);
   }
 
   /** {@inheritDoc} */
   @Override
-  public FloatNdArray read(FloatDataBuffer dst) {
+  public FloatNdArray copyTo(FloatDataBuffer dst) {
     // set the values in buf to the default, then overwrite with indices/values
     Float[] defaults = new Float[(int) shape().size()];
     Arrays.fill(defaults, getDefaultValue());
@@ -327,7 +327,7 @@ public class FloatSparseNdArray extends AbstractSparseNdArray<Float, FloatNdArra
 
   /** {@inheritDoc} */
   @Override
-  public FloatNdArray write(FloatDataBuffer src) {
+  public FloatNdArray copyFrom(FloatDataBuffer src) {
     List<long[]> indices = new ArrayList<>();
     List<Float> values = new ArrayList<>();
 
@@ -351,8 +351,8 @@ public class FloatSparseNdArray extends AbstractSparseNdArray<Float, FloatNdArra
 
   /** {@inheritDoc} */
   @Override
-  public FloatNdArray write(DataBuffer<Float> src) {
-    return write((FloatDataBuffer) src);
+  public FloatNdArray copyFrom(DataBuffer<Float> src) {
+    return copyFrom((FloatDataBuffer) src);
   }
 
   /**
@@ -362,7 +362,7 @@ public class FloatSparseNdArray extends AbstractSparseNdArray<Float, FloatNdArra
    */
   public FloatNdArray toDense() {
     FloatDataBuffer dataBuffer = DataBuffers.ofFloats(shape().size());
-    read(dataBuffer);
+    copyTo(dataBuffer);
     return NdArrays.wrap(shape(), dataBuffer);
   }
 
@@ -374,8 +374,8 @@ public class FloatSparseNdArray extends AbstractSparseNdArray<Float, FloatNdArra
    */
   public FloatNdArray fromDense(FloatNdArray src) {
     FloatDataBuffer buffer = DataBuffers.ofFloats(src.size());
-    src.read(buffer);
-    write(buffer);
+    src.copyTo(buffer);
+    copyFrom(buffer);
     return this;
   }
 

--- a/ndarray/src/main/java/org/tensorflow/ndarray/impl/sparse/IntSparseNdArray.java
+++ b/ndarray/src/main/java/org/tensorflow/ndarray/impl/sparse/IntSparseNdArray.java
@@ -116,7 +116,7 @@ public class IntSparseNdArray extends AbstractSparseNdArray<Integer, IntNdArray>
   IntSparseNdArray(IntDataBuffer dataBuffer, int defaultValue, DimensionalSpace dimensions) {
     super(defaultValue, dimensions);
     // use write to set up the indices and values
-    write(dataBuffer);
+    copyFrom(dataBuffer);
   }
 
   /**
@@ -269,7 +269,7 @@ public class IntSparseNdArray extends AbstractSparseNdArray<Integer, IntNdArray>
    */
   public static IntSparseNdArray create(IntNdArray src) {
     IntDataBuffer buffer = DataBuffers.ofInts(src.size());
-    src.read(buffer);
+    src.copyTo(buffer);
     return new IntSparseNdArray(buffer, DimensionalSpace.create(src.shape()));
   }
 
@@ -282,7 +282,7 @@ public class IntSparseNdArray extends AbstractSparseNdArray<Integer, IntNdArray>
    */
   public static IntSparseNdArray create(IntNdArray src, int defaultValue) {
     IntDataBuffer buffer = DataBuffers.ofInts(src.size());
-    src.read(buffer);
+    src.copyTo(buffer);
     return new IntSparseNdArray(buffer, defaultValue, DimensionalSpace.create(src.shape()));
   }
 
@@ -316,13 +316,13 @@ public class IntSparseNdArray extends AbstractSparseNdArray<Integer, IntNdArray>
 
   /** {@inheritDoc} */
   @Override
-  public IntNdArray read(DataBuffer<Integer> dst) {
-    return read((IntDataBuffer) dst);
+  public IntNdArray copyTo(DataBuffer<Integer> dst) {
+    return copyTo((IntDataBuffer) dst);
   }
 
   /** {@inheritDoc} */
   @Override
-  public IntNdArray read(IntDataBuffer dst) {
+  public IntNdArray copyTo(IntDataBuffer dst) {
     // set the values in buf to the default, then overwrite with indices/values
     Integer[] defaults = new Integer[(int) shape().size()];
     Arrays.fill(defaults, getDefaultValue());
@@ -342,7 +342,7 @@ public class IntSparseNdArray extends AbstractSparseNdArray<Integer, IntNdArray>
 
   /** {@inheritDoc} */
   @Override
-  public IntNdArray write(IntDataBuffer src) {
+  public IntNdArray copyFrom(IntDataBuffer src) {
     List<long[]> indices = new ArrayList<>();
     List<Integer> values = new ArrayList<>();
 
@@ -366,8 +366,8 @@ public class IntSparseNdArray extends AbstractSparseNdArray<Integer, IntNdArray>
 
   /** {@inheritDoc} */
   @Override
-  public IntNdArray write(DataBuffer<Integer> src) {
-    return write((IntDataBuffer) src);
+  public IntNdArray copyFrom(DataBuffer<Integer> src) {
+    return copyFrom((IntDataBuffer) src);
   }
 
   /**
@@ -377,7 +377,7 @@ public class IntSparseNdArray extends AbstractSparseNdArray<Integer, IntNdArray>
    */
   public IntNdArray toDense() {
     IntDataBuffer dataBuffer = DataBuffers.ofInts(shape().size());
-    read(dataBuffer);
+    copyTo(dataBuffer);
     return NdArrays.wrap(shape(), dataBuffer);
   }
 
@@ -389,8 +389,8 @@ public class IntSparseNdArray extends AbstractSparseNdArray<Integer, IntNdArray>
    */
   public IntNdArray fromDense(IntNdArray src) {
     IntDataBuffer buffer = DataBuffers.ofInts(src.size());
-    src.read(buffer);
-    write(buffer);
+    src.copyTo(buffer);
+    copyFrom(buffer);
     return this;
   }
 

--- a/ndarray/src/main/java/org/tensorflow/ndarray/impl/sparse/LongSparseNdArray.java
+++ b/ndarray/src/main/java/org/tensorflow/ndarray/impl/sparse/LongSparseNdArray.java
@@ -117,7 +117,7 @@ public class LongSparseNdArray extends AbstractSparseNdArray<Long, LongNdArray>
   LongSparseNdArray(LongDataBuffer dataBuffer, long defaultValue, DimensionalSpace dimensions) {
     super(defaultValue, dimensions);
     // use write to set up the indices and values
-    write(dataBuffer);
+    copyFrom(dataBuffer);
   }
 
   /**
@@ -254,7 +254,7 @@ public class LongSparseNdArray extends AbstractSparseNdArray<Long, LongNdArray>
    */
   public static LongSparseNdArray create(LongNdArray src) {
     LongDataBuffer buffer = DataBuffers.ofLongs(src.size());
-    src.read(buffer);
+    src.copyTo(buffer);
     return new LongSparseNdArray(buffer, DimensionalSpace.create(src.shape()));
   }
 
@@ -267,7 +267,7 @@ public class LongSparseNdArray extends AbstractSparseNdArray<Long, LongNdArray>
    */
   public static LongSparseNdArray create(LongNdArray src, long defaultValue) {
     LongDataBuffer buffer = DataBuffers.ofLongs(src.size());
-    src.read(buffer);
+    src.copyTo(buffer);
     return new LongSparseNdArray(buffer, defaultValue, DimensionalSpace.create(src.shape()));
   }
 
@@ -301,13 +301,13 @@ public class LongSparseNdArray extends AbstractSparseNdArray<Long, LongNdArray>
 
   /** {@inheritDoc} */
   @Override
-  public LongNdArray read(DataBuffer<Long> dst) {
-    return read((LongDataBuffer) dst);
+  public LongNdArray copyTo(DataBuffer<Long> dst) {
+    return copyTo((LongDataBuffer) dst);
   }
 
   /** {@inheritDoc} */
   @Override
-  public LongNdArray read(LongDataBuffer dst) {
+  public LongNdArray copyTo(LongDataBuffer dst) {
     // set the values in buf to the default, then overwrite with indices/values
     Long[] defaults = new Long[(int) shape().size()];
     Arrays.fill(defaults, getDefaultValue());
@@ -327,7 +327,7 @@ public class LongSparseNdArray extends AbstractSparseNdArray<Long, LongNdArray>
 
   /** {@inheritDoc} */
   @Override
-  public LongNdArray write(LongDataBuffer src) {
+  public LongNdArray copyFrom(LongDataBuffer src) {
     List<long[]> indices = new ArrayList<>();
     List<Long> values = new ArrayList<>();
 
@@ -351,8 +351,8 @@ public class LongSparseNdArray extends AbstractSparseNdArray<Long, LongNdArray>
 
   /** {@inheritDoc} */
   @Override
-  public LongNdArray write(DataBuffer<Long> src) {
-    return write((LongDataBuffer) src);
+  public LongNdArray copyFrom(DataBuffer<Long> src) {
+    return copyFrom((LongDataBuffer) src);
   }
 
   /**
@@ -362,7 +362,7 @@ public class LongSparseNdArray extends AbstractSparseNdArray<Long, LongNdArray>
    */
   public LongNdArray toDense() {
     LongDataBuffer dataBuffer = DataBuffers.ofLongs(shape().size());
-    read(dataBuffer);
+    copyTo(dataBuffer);
     return NdArrays.wrap(shape(), dataBuffer);
   }
 
@@ -374,8 +374,8 @@ public class LongSparseNdArray extends AbstractSparseNdArray<Long, LongNdArray>
    */
   public LongNdArray fromDense(LongNdArray src) {
     LongDataBuffer buffer = DataBuffers.ofLongs(src.size());
-    src.read(buffer);
-    write(buffer);
+    src.copyTo(buffer);
+    copyFrom(buffer);
     return this;
   }
 

--- a/ndarray/src/main/java/org/tensorflow/ndarray/impl/sparse/ShortSparseNdArray.java
+++ b/ndarray/src/main/java/org/tensorflow/ndarray/impl/sparse/ShortSparseNdArray.java
@@ -118,7 +118,7 @@ public class ShortSparseNdArray extends AbstractSparseNdArray<Short, ShortNdArra
   ShortSparseNdArray(ShortDataBuffer dataBuffer, short defaultValue, DimensionalSpace dimensions) {
     super(defaultValue, dimensions);
     // use write to set up the indices and values
-    write(dataBuffer);
+    copyFrom(dataBuffer);
   }
 
   /**
@@ -255,7 +255,7 @@ public class ShortSparseNdArray extends AbstractSparseNdArray<Short, ShortNdArra
    */
   public static ShortSparseNdArray create(ShortNdArray src) {
     ShortDataBuffer buffer = DataBuffers.ofShorts(src.size());
-    src.read(buffer);
+    src.copyTo(buffer);
     return new ShortSparseNdArray(buffer, DimensionalSpace.create(src.shape()));
   }
 
@@ -268,7 +268,7 @@ public class ShortSparseNdArray extends AbstractSparseNdArray<Short, ShortNdArra
    */
   public static ShortSparseNdArray create(ShortNdArray src, short defaultValue) {
     ShortDataBuffer buffer = DataBuffers.ofShorts(src.size());
-    src.read(buffer);
+    src.copyTo(buffer);
     return new ShortSparseNdArray(buffer, defaultValue, DimensionalSpace.create(src.shape()));
   }
 
@@ -302,13 +302,13 @@ public class ShortSparseNdArray extends AbstractSparseNdArray<Short, ShortNdArra
 
   /** {@inheritDoc} */
   @Override
-  public ShortNdArray read(DataBuffer<Short> dst) {
-    return read((ShortDataBuffer) dst);
+  public ShortNdArray copyTo(DataBuffer<Short> dst) {
+    return copyTo((ShortDataBuffer) dst);
   }
 
   /** {@inheritDoc} */
   @Override
-  public ShortNdArray read(ShortDataBuffer dst) {
+  public ShortNdArray copyTo(ShortDataBuffer dst) {
     // set the values in buf to the default, then overwrite with indices/values
     Short[] defaults = new Short[(int) shape().size()];
     Arrays.fill(defaults, getDefaultValue());
@@ -328,7 +328,7 @@ public class ShortSparseNdArray extends AbstractSparseNdArray<Short, ShortNdArra
 
   /** {@inheritDoc} */
   @Override
-  public ShortNdArray write(ShortDataBuffer src) {
+  public ShortNdArray copyFrom(ShortDataBuffer src) {
     List<long[]> indices = new ArrayList<>();
     List<Short> values = new ArrayList<>();
 
@@ -352,8 +352,8 @@ public class ShortSparseNdArray extends AbstractSparseNdArray<Short, ShortNdArra
 
   /** {@inheritDoc} */
   @Override
-  public ShortNdArray write(DataBuffer<Short> src) {
-    return write((ShortDataBuffer) src);
+  public ShortNdArray copyFrom(DataBuffer<Short> src) {
+    return copyFrom((ShortDataBuffer) src);
   }
 
   /**
@@ -363,7 +363,7 @@ public class ShortSparseNdArray extends AbstractSparseNdArray<Short, ShortNdArra
    */
   public ShortNdArray toDense() {
     ShortDataBuffer dataBuffer = DataBuffers.ofShorts(shape().size());
-    read(dataBuffer);
+    copyTo(dataBuffer);
     return NdArrays.wrap(shape(), dataBuffer);
   }
 
@@ -375,8 +375,8 @@ public class ShortSparseNdArray extends AbstractSparseNdArray<Short, ShortNdArra
    */
   public ShortNdArray fromDense(ShortNdArray src) {
     ShortDataBuffer buffer = DataBuffers.ofShorts(src.size());
-    src.read(buffer);
-    write(buffer);
+    src.copyTo(buffer);
+    copyFrom(buffer);
     return this;
   }
 

--- a/ndarray/src/main/java/org/tensorflow/ndarray/impl/sparse/SparseNdArray.java
+++ b/ndarray/src/main/java/org/tensorflow/ndarray/impl/sparse/SparseNdArray.java
@@ -123,7 +123,7 @@ public class SparseNdArray<T, U extends NdArray<T>> extends AbstractSparseNdArra
     super(defaultValue, dimensions);
     this.type = type;
     // use write to set up the indices and values
-    write(dataBuffer);
+    copyFrom(dataBuffer);
   }
 
   /**
@@ -266,7 +266,7 @@ public class SparseNdArray<T, U extends NdArray<T>> extends AbstractSparseNdArra
    */
   public static <T, U extends NdArray<T>> SparseNdArray<T, U> create(Class<T> type, U src) {
     DataBuffer<T> buffer = DataBuffers.ofObjects(type, src.size());
-    src.read(buffer);
+    src.copyTo(buffer);
     return new SparseNdArray<>(type, buffer, DimensionalSpace.create(src.shape()));
   }
   /**
@@ -279,7 +279,7 @@ public class SparseNdArray<T, U extends NdArray<T>> extends AbstractSparseNdArra
   public static <T, U extends NdArray<T>> SparseNdArray<T, U> create(
       Class<T> type, U src, T defaultValue) {
     DataBuffer<T> buffer = DataBuffers.ofObjects(type, src.size());
-    src.read(buffer);
+    src.copyTo(buffer);
     return new SparseNdArray<>(type, buffer, defaultValue, DimensionalSpace.create(src.shape()));
   }
 
@@ -312,7 +312,7 @@ public class SparseNdArray<T, U extends NdArray<T>> extends AbstractSparseNdArra
 
   /** {@inheritDoc} */
   @Override
-  public NdArray<T> read(DataBuffer<T> dst) {
+  public NdArray<T> copyTo(DataBuffer<T> dst) {
     // set the values in buf to the default, then overwrite with indices/values
     @SuppressWarnings("unchecked")
     T[] defaults = (T[]) Array.newInstance(type, (int) dst.size());
@@ -336,7 +336,7 @@ public class SparseNdArray<T, U extends NdArray<T>> extends AbstractSparseNdArra
   @SuppressWarnings({
     "unchecked",
   })
-  public NdArray<T> write(DataBuffer<T> src) {
+  public NdArray<T> copyFrom(DataBuffer<T> src) {
     List<long[]> indices = new ArrayList<>();
     List<T> values = new ArrayList<>();
 
@@ -368,7 +368,7 @@ public class SparseNdArray<T, U extends NdArray<T>> extends AbstractSparseNdArra
   @SuppressWarnings("unchecked")
   public U toDense() {
     DataBuffer<T> dataBuffer = DataBuffers.ofObjects(type, shape().size());
-    read(dataBuffer);
+    copyTo(dataBuffer);
     // unchecked cast, suppressed.
     return (U) NdArrays.wrap(shape(), dataBuffer);
   }
@@ -381,8 +381,8 @@ public class SparseNdArray<T, U extends NdArray<T>> extends AbstractSparseNdArra
    */
   public NdArray<T> fromDense(NdArray<T> src) {
     DataBuffer<T> buffer = DataBuffers.ofObjects(type, src.size());
-    src.read(buffer);
-    write(buffer);
+    src.copyTo(buffer);
+    copyFrom(buffer);
     return this;
   }
 

--- a/ndarray/src/main/java/org/tensorflow/ndarray/impl/sparse/slice/BooleanSparseSlice.java
+++ b/ndarray/src/main/java/org/tensorflow/ndarray/impl/sparse/slice/BooleanSparseSlice.java
@@ -49,7 +49,7 @@ public class BooleanSparseSlice extends SparseSlice<Boolean, BooleanNdArray>
   @Override
   public BooleanNdArray toDense() {
     BooleanDataBuffer dataBuffer = DataBuffers.ofBooleans(shape().size());
-    read(dataBuffer);
+    copyTo(dataBuffer);
     return NdArrays.wrap(shape(), dataBuffer);
   }
 
@@ -75,7 +75,7 @@ public class BooleanSparseSlice extends SparseSlice<Boolean, BooleanNdArray>
 
   /** {@inheritDoc} */
   @Override
-  public BooleanNdArray read(DataBuffer<Boolean> dst) {
+  public BooleanNdArray copyTo(DataBuffer<Boolean> dst) {
     // zero out buf.
     Boolean[] defaults = new Boolean[(int) shape().size()];
     dst.write(defaults);
@@ -93,17 +93,17 @@ public class BooleanSparseSlice extends SparseSlice<Boolean, BooleanNdArray>
   }
 
   @Override
-  public BooleanNdArray read(BooleanDataBuffer dst) {
-    return read((DataBuffer<Boolean>) dst);
+  public BooleanNdArray copyTo(BooleanDataBuffer dst) {
+    return copyTo((DataBuffer<Boolean>) dst);
   }
 
   @Override
-  public BooleanNdArray write(DataBuffer<Boolean> src) {
+  public BooleanNdArray copyFrom(DataBuffer<Boolean> src) {
     throw new ReadOnlyBufferException();
   }
 
   @Override
-  public BooleanNdArray write(BooleanDataBuffer src) {
+  public BooleanNdArray copyFrom(BooleanDataBuffer src) {
     throw new ReadOnlyBufferException();
   }
 

--- a/ndarray/src/main/java/org/tensorflow/ndarray/impl/sparse/slice/ByteSparseSlice.java
+++ b/ndarray/src/main/java/org/tensorflow/ndarray/impl/sparse/slice/ByteSparseSlice.java
@@ -48,7 +48,7 @@ public class ByteSparseSlice extends SparseSlice<Byte, ByteNdArray> implements B
   @Override
   public ByteNdArray toDense() {
     ByteDataBuffer dataBuffer = DataBuffers.ofBytes(shape().size());
-    read(dataBuffer);
+    copyTo(dataBuffer);
     return NdArrays.wrap(shape(), dataBuffer);
   }
 
@@ -74,7 +74,7 @@ public class ByteSparseSlice extends SparseSlice<Byte, ByteNdArray> implements B
 
   /** {@inheritDoc} */
   @Override
-  public ByteNdArray read(DataBuffer<Byte> dst) {
+  public ByteNdArray copyTo(DataBuffer<Byte> dst) {
     // zero out buf.
     Byte[] defaults = new Byte[(int) shape().size()];
     dst.write(defaults);
@@ -92,17 +92,17 @@ public class ByteSparseSlice extends SparseSlice<Byte, ByteNdArray> implements B
   }
 
   @Override
-  public ByteNdArray read(ByteDataBuffer dst) {
-    return read((DataBuffer<Byte>) dst);
+  public ByteNdArray copyTo(ByteDataBuffer dst) {
+    return this.copyTo((DataBuffer<Byte>) dst);
   }
 
   @Override
-  public ByteNdArray write(DataBuffer<Byte> src) {
+  public ByteNdArray copyFrom(DataBuffer<Byte> src) {
     throw new ReadOnlyBufferException();
   }
 
   @Override
-  public ByteNdArray write(ByteDataBuffer src) {
+  public ByteNdArray copyFrom(ByteDataBuffer src) {
     throw new ReadOnlyBufferException();
   }
 

--- a/ndarray/src/main/java/org/tensorflow/ndarray/impl/sparse/slice/DoubleSparseSlice.java
+++ b/ndarray/src/main/java/org/tensorflow/ndarray/impl/sparse/slice/DoubleSparseSlice.java
@@ -49,7 +49,7 @@ public class DoubleSparseSlice extends SparseSlice<Double, DoubleNdArray> implem
   @Override
   public DoubleNdArray toDense() {
     DoubleDataBuffer dataBuffer = DataBuffers.ofDoubles(shape().size());
-    read(dataBuffer);
+    copyTo(dataBuffer);
     return NdArrays.wrap(shape(), dataBuffer);
   }
 
@@ -75,7 +75,7 @@ public class DoubleSparseSlice extends SparseSlice<Double, DoubleNdArray> implem
 
   /** {@inheritDoc} */
   @Override
-  public DoubleNdArray read(DataBuffer<Double> dst) {
+  public DoubleNdArray copyTo(DataBuffer<Double> dst) {
     // set the values in buf to the default, then overwrite with indices/values
     Double[] defaults = new Double[(int) shape().size()];
     Arrays.fill(defaults, getDefaultValue());
@@ -94,17 +94,17 @@ public class DoubleSparseSlice extends SparseSlice<Double, DoubleNdArray> implem
   }
 
   @Override
-  public DoubleNdArray read(DoubleDataBuffer dst) {
-    return read((DataBuffer<Double>) dst);
+  public DoubleNdArray copyTo(DoubleDataBuffer dst) {
+    return this.copyTo((DataBuffer<Double>) dst);
   }
 
   @Override
-  public DoubleNdArray write(DataBuffer<Double> src) {
+  public DoubleNdArray copyFrom(DataBuffer<Double> src) {
     throw new ReadOnlyBufferException();
   }
 
   @Override
-  public DoubleNdArray write(DoubleDataBuffer src) {
+  public DoubleNdArray copyFrom(DoubleDataBuffer src) {
     throw new ReadOnlyBufferException();
   }
 

--- a/ndarray/src/main/java/org/tensorflow/ndarray/impl/sparse/slice/FloatSparseSlice.java
+++ b/ndarray/src/main/java/org/tensorflow/ndarray/impl/sparse/slice/FloatSparseSlice.java
@@ -49,7 +49,7 @@ public class FloatSparseSlice extends SparseSlice<Float, FloatNdArray> implement
   @Override
   public FloatNdArray toDense() {
     FloatDataBuffer dataBuffer = DataBuffers.ofFloats(shape().size());
-    read(dataBuffer);
+    copyTo(dataBuffer);
     return NdArrays.wrap(shape(), dataBuffer);
   }
 
@@ -75,7 +75,7 @@ public class FloatSparseSlice extends SparseSlice<Float, FloatNdArray> implement
 
   /** {@inheritDoc} */
   @Override
-  public FloatNdArray read(DataBuffer<Float> dst) {
+  public FloatNdArray copyTo(DataBuffer<Float> dst) {
     // set the values in buf to the default, then overwrite with indices/values
     Float[] defaults = new Float[(int) shape().size()];
     Arrays.fill(defaults, getDefaultValue());
@@ -94,17 +94,17 @@ public class FloatSparseSlice extends SparseSlice<Float, FloatNdArray> implement
   }
 
   @Override
-  public FloatNdArray read(FloatDataBuffer dst) {
-    return read((DataBuffer<Float>) dst);
+  public FloatNdArray copyTo(FloatDataBuffer dst) {
+    return this.copyTo((DataBuffer<Float>) dst);
   }
 
   @Override
-  public FloatNdArray write(DataBuffer<Float> src) {
+  public FloatNdArray copyFrom(DataBuffer<Float> src) {
     throw new ReadOnlyBufferException();
   }
 
   @Override
-  public FloatNdArray write(FloatDataBuffer src) {
+  public FloatNdArray copyFrom(FloatDataBuffer src) {
     throw new ReadOnlyBufferException();
   }
 

--- a/ndarray/src/main/java/org/tensorflow/ndarray/impl/sparse/slice/IntSparseSlice.java
+++ b/ndarray/src/main/java/org/tensorflow/ndarray/impl/sparse/slice/IntSparseSlice.java
@@ -49,7 +49,7 @@ public class IntSparseSlice extends SparseSlice<Integer, IntNdArray> implements 
   @Override
   public IntNdArray toDense() {
     IntDataBuffer dataBuffer = DataBuffers.ofInts(shape().size());
-    read(dataBuffer);
+    copyTo(dataBuffer);
     return NdArrays.wrap(shape(), dataBuffer);
   }
 
@@ -75,7 +75,7 @@ public class IntSparseSlice extends SparseSlice<Integer, IntNdArray> implements 
 
   /** {@inheritDoc} */
   @Override
-  public IntNdArray read(DataBuffer<Integer> dst) {
+  public IntNdArray copyTo(DataBuffer<Integer> dst) {
     // set the values in buf to the default, then overwrite with indices/values
     Integer[] defaults = new Integer[(int) shape().size()];
     Arrays.fill(defaults, getDefaultValue());
@@ -94,17 +94,17 @@ public class IntSparseSlice extends SparseSlice<Integer, IntNdArray> implements 
   }
 
   @Override
-  public IntNdArray read(IntDataBuffer dst) {
-    return read((DataBuffer<Integer>) dst);
+  public IntNdArray copyTo(IntDataBuffer dst) {
+    return this.copyTo((DataBuffer<Integer>) dst);
   }
 
   @Override
-  public IntNdArray write(DataBuffer<Integer> src) {
+  public IntNdArray copyFrom(DataBuffer<Integer> src) {
     throw new ReadOnlyBufferException();
   }
 
   @Override
-  public IntNdArray write(IntDataBuffer src) {
+  public IntNdArray copyFrom(IntDataBuffer src) {
     throw new ReadOnlyBufferException();
   }
 

--- a/ndarray/src/main/java/org/tensorflow/ndarray/impl/sparse/slice/LongSparseSlice.java
+++ b/ndarray/src/main/java/org/tensorflow/ndarray/impl/sparse/slice/LongSparseSlice.java
@@ -49,7 +49,7 @@ public class LongSparseSlice extends SparseSlice<Long, LongNdArray> implements L
   @Override
   public LongNdArray toDense() {
     LongDataBuffer dataBuffer = DataBuffers.ofLongs(shape().size());
-    read(dataBuffer);
+    copyTo(dataBuffer);
     return NdArrays.wrap(shape(), dataBuffer);
   }
 
@@ -75,7 +75,7 @@ public class LongSparseSlice extends SparseSlice<Long, LongNdArray> implements L
 
   /** {@inheritDoc} */
   @Override
-  public LongNdArray read(DataBuffer<Long> dst) {
+  public LongNdArray copyTo(DataBuffer<Long> dst) {
     // set the values in buf to the default, then overwrite with indices/values
     Long[] defaults = new Long[(int) shape().size()];
     Arrays.fill(defaults, getDefaultValue());
@@ -94,17 +94,17 @@ public class LongSparseSlice extends SparseSlice<Long, LongNdArray> implements L
   }
 
   @Override
-  public LongNdArray read(LongDataBuffer dst) {
-    return read((DataBuffer<Long>) dst);
+  public LongNdArray copyTo(LongDataBuffer dst) {
+    return copyTo((DataBuffer<Long>) dst);
   }
 
   @Override
-  public LongNdArray write(DataBuffer<Long> src) {
+  public LongNdArray copyFrom(DataBuffer<Long> src) {
     throw new ReadOnlyBufferException();
   }
 
   @Override
-  public LongNdArray write(LongDataBuffer src) {
+  public LongNdArray copyFrom(LongDataBuffer src) {
     throw new ReadOnlyBufferException();
   }
 

--- a/ndarray/src/main/java/org/tensorflow/ndarray/impl/sparse/slice/ObjectSparseSlice.java
+++ b/ndarray/src/main/java/org/tensorflow/ndarray/impl/sparse/slice/ObjectSparseSlice.java
@@ -48,7 +48,7 @@ public class ObjectSparseSlice<T, U extends NdArray<T>> extends SparseSlice<T, U
   @SuppressWarnings("unchecked")
   public U toDense() {
     DataBuffer<T> dataBuffer = DataBuffers.ofObjects(getType(), shape().size());
-    read(dataBuffer);
+    copyTo(dataBuffer);
     // unchecked NdArray<T> to U
     return (U) NdArrays.wrap(shape(), dataBuffer);
   }
@@ -66,7 +66,7 @@ public class ObjectSparseSlice<T, U extends NdArray<T>> extends SparseSlice<T, U
   /** {@inheritDoc} */
   @Override
   @SuppressWarnings("unchecked")
-  public U read(DataBuffer<T> dst) {
+  public U copyTo(DataBuffer<T> dst) {
     // unchecked Object to T[]
     T[] defaults = (T[]) Array.newInstance(getType(), (int) dst.size());
     Arrays.fill(defaults, getDefaultValue());

--- a/ndarray/src/main/java/org/tensorflow/ndarray/impl/sparse/slice/ShortSparseSlice.java
+++ b/ndarray/src/main/java/org/tensorflow/ndarray/impl/sparse/slice/ShortSparseSlice.java
@@ -49,7 +49,7 @@ public class ShortSparseSlice extends SparseSlice<Short, ShortNdArray> implement
   @Override
   public ShortNdArray toDense() {
     ShortDataBuffer dataBuffer = DataBuffers.ofShorts(shape().size());
-    read(dataBuffer);
+    copyTo(dataBuffer);
     return NdArrays.wrap(shape(), dataBuffer);
   }
 
@@ -75,7 +75,7 @@ public class ShortSparseSlice extends SparseSlice<Short, ShortNdArray> implement
 
   /** {@inheritDoc} */
   @Override
-  public ShortNdArray read(DataBuffer<Short> dst) {
+  public ShortNdArray copyTo(DataBuffer<Short> dst) {
     // set the values in buf to the default, then overwrite with indices/values
     Short[] defaults = new Short[(int) shape().size()];
     Arrays.fill(defaults, getDefaultValue());
@@ -94,17 +94,17 @@ public class ShortSparseSlice extends SparseSlice<Short, ShortNdArray> implement
   }
 
   @Override
-  public ShortNdArray read(ShortDataBuffer dst) {
-    return read((DataBuffer<Short>) dst);
+  public ShortNdArray copyTo(ShortDataBuffer dst) {
+    return this.copyTo((DataBuffer<Short>) dst);
   }
 
   @Override
-  public ShortNdArray write(DataBuffer<Short> src) {
+  public ShortNdArray copyFrom(DataBuffer<Short> src) {
     throw new ReadOnlyBufferException();
   }
 
   @Override
-  public ShortNdArray write(ShortDataBuffer src) {
+  public ShortNdArray copyFrom(ShortDataBuffer src) {
     throw new ReadOnlyBufferException();
   }
 

--- a/ndarray/src/main/java/org/tensorflow/ndarray/impl/sparse/slice/SparseSlice.java
+++ b/ndarray/src/main/java/org/tensorflow/ndarray/impl/sparse/slice/SparseSlice.java
@@ -133,7 +133,7 @@ public abstract class SparseSlice<T, U extends NdArray<T>> extends AbstractSpars
 
   /** {@inheritDoc} */
   @Override
-  public NdArray<T> write(DataBuffer<T> src) {
+  public NdArray<T> copyFrom(DataBuffer<T> src) {
     throw new ReadOnlyBufferException();
   }
 

--- a/ndarray/src/test/java/org/tensorflow/ndarray/NdArrayTestBase.java
+++ b/ndarray/src/test/java/org/tensorflow/ndarray/NdArrayTestBase.java
@@ -258,7 +258,7 @@ public abstract class NdArrayTestBase<T> {
       buffer.setObject(valueOf(val), val);
     }
     NdArray<T> matrix = allocate(Shape.of(3, 5));
-    matrix.write(buffer);
+    matrix.copyFrom(buffer);
     assertEquals(valueOf(0L), matrix.getObject(0, 0));
     assertEquals(valueOf(4L), matrix.getObject(0, 4));
     assertEquals(valueOf(5L), matrix.getObject(1, 0));
@@ -266,7 +266,7 @@ public abstract class NdArrayTestBase<T> {
     assertEquals(valueOf(14L), matrix.getObject(2, 4));
 
     matrix.setObject(valueOf(100L), 1, 0);
-    matrix.read(buffer);
+    matrix.copyTo(buffer);
     assertEquals(valueOf(0L), buffer.getObject(0));
     assertEquals(valueOf(4L), buffer.getObject(4));
     assertEquals(valueOf(100L), buffer.getObject(5));
@@ -274,13 +274,13 @@ public abstract class NdArrayTestBase<T> {
     assertEquals(valueOf(14L), buffer.getObject(14));
 
     try {
-      matrix.write(buffer.narrow(10));
+      matrix.copyFrom(buffer.narrow(10));
       fail();
     } catch (BufferUnderflowException e) {
       // as expected
     }
     try {
-      matrix.read(buffer.narrow(10));
+      matrix.copyTo(buffer.narrow(10));
       fail();
     } catch (BufferOverflowException e) {
       // as expected

--- a/ndarray/src/test/java/org/tensorflow/ndarray/impl/sparse/BooleanSparseNdArrayTest.java
+++ b/ndarray/src/test/java/org/tensorflow/ndarray/impl/sparse/BooleanSparseNdArrayTest.java
@@ -47,12 +47,12 @@ class BooleanSparseNdArrayTest {
   }
 
   @Test
-  public void testRead() {
+  public void testCopyToBuffer() {
     BooleanSparseNdArray instance =
         new BooleanSparseNdArray(indices, values, DimensionalSpace.create(shape));
     BooleanDataBuffer dataBuffer = DataBuffers.ofBooleans(instance.shape().size());
 
-    instance.read(dataBuffer);
+    instance.copyTo(dataBuffer);
 
     boolean[] array = new boolean[denseArray.length];
     dataBuffer.read(array);
@@ -60,12 +60,12 @@ class BooleanSparseNdArrayTest {
   }
 
   @Test
-  public void testWrite() {
+  public void testCopyFromBuffer() {
 
     BooleanDataBuffer dataBuffer = RawDataBufferFactory.create(denseArray, false);
     // use a zero buffer
     BooleanSparseNdArray instance = BooleanSparseNdArray.create(DimensionalSpace.create(shape));
-    instance.write(dataBuffer);
+    instance.copyFrom(dataBuffer);
 
     assertEquals(indices, instance.getIndices());
     assertEquals(values, instance.getValues());
@@ -84,7 +84,7 @@ class BooleanSparseNdArrayTest {
     // use a zero buffer
     BooleanSparseNdArray instance =
         BooleanSparseNdArray.create(true, DimensionalSpace.create(shape));
-    instance.write(dataBuffer);
+    instance.copyFrom(dataBuffer);
 
     assertEquals(indices, instance.getIndices());
     assertEquals(valuesDefault, instance.getValues());
@@ -274,7 +274,7 @@ class BooleanSparseNdArrayTest {
     BooleanDataBuffer dataBuffer = RawDataBufferFactory.create(denseArray, false);
     // use a zero buffer
     BooleanSparseNdArray instanceB = BooleanSparseNdArray.create(DimensionalSpace.create(shape));
-    instanceB.write(dataBuffer);
+    instanceB.copyFrom(dataBuffer);
     assertEquals(instance, instanceB);
 
     BooleanSparseNdArray instanceC =

--- a/ndarray/src/test/java/org/tensorflow/ndarray/impl/sparse/ByteSparseNdArrayTest.java
+++ b/ndarray/src/test/java/org/tensorflow/ndarray/impl/sparse/ByteSparseNdArrayTest.java
@@ -45,12 +45,12 @@ class ByteSparseNdArrayTest {
   }
 
   @Test
-  public void testRead() {
+  public void testCopyToBuffer() {
     ByteSparseNdArray instance =
         new ByteSparseNdArray(indices, values, DimensionalSpace.create(shape));
     ByteDataBuffer dataBuffer = DataBuffers.ofBytes(instance.shape().size());
 
-    instance.read(dataBuffer);
+    instance.copyTo(dataBuffer);
 
     byte[] array = new byte[denseArray.length];
     dataBuffer.read(array);
@@ -58,12 +58,12 @@ class ByteSparseNdArrayTest {
   }
 
   @Test
-  public void testWrite() {
+  public void testCopyFromBuffer() {
 
     ByteDataBuffer dataBuffer = RawDataBufferFactory.create(denseArray, false);
     // use a zero buffer
     ByteSparseNdArray instance = ByteSparseNdArray.create(DimensionalSpace.create(shape));
-    instance.write(dataBuffer);
+    instance.copyFrom(dataBuffer);
 
     assertEquals(indices, instance.getIndices());
     assertEquals(values, instance.getValues());
@@ -80,7 +80,7 @@ class ByteSparseNdArrayTest {
     // use a zero buffer
     ByteSparseNdArray instance =
         ByteSparseNdArray.create((byte) -1, DimensionalSpace.create(shape));
-    instance.write(dataBuffer);
+    instance.copyFrom(dataBuffer);
 
     assertEquals(indices, instance.getIndices());
     assertEquals(values, instance.getValues());
@@ -265,7 +265,7 @@ class ByteSparseNdArrayTest {
     ByteDataBuffer dataBuffer = RawDataBufferFactory.create(denseArray, false);
     // use a zero buffer
     ByteSparseNdArray instanceB = ByteSparseNdArray.create(DimensionalSpace.create(shape));
-    instanceB.write(dataBuffer);
+    instanceB.copyFrom(dataBuffer);
     assertEquals(instance, instanceB);
 
     ByteSparseNdArray instanceC =

--- a/ndarray/src/test/java/org/tensorflow/ndarray/impl/sparse/DoubleSparseNdArrayTest.java
+++ b/ndarray/src/test/java/org/tensorflow/ndarray/impl/sparse/DoubleSparseNdArrayTest.java
@@ -49,12 +49,12 @@ class DoubleSparseNdArrayTest {
   }
 
   @Test
-  public void testRead() {
+  public void testCopyToBuffer() {
     DoubleSparseNdArray instance =
         new DoubleSparseNdArray(indices, values, DimensionalSpace.create(shape));
     DoubleDataBuffer dataBuffer = DataBuffers.ofDoubles(instance.shape().size());
 
-    instance.read(dataBuffer);
+    instance.copyTo(dataBuffer);
 
     double[] array = new double[denseArray.length];
     dataBuffer.read(array);
@@ -62,12 +62,12 @@ class DoubleSparseNdArrayTest {
   }
 
   @Test
-  public void testWrite() {
+  public void testCopyFromBuffer() {
 
     DoubleDataBuffer dataBuffer = NioDataBufferFactory.create(DoubleBuffer.wrap(denseArray));
     // use a zero buffer
     DoubleSparseNdArray instance = DoubleSparseNdArray.create(DimensionalSpace.create(shape));
-    instance.write(dataBuffer);
+    instance.copyFrom(dataBuffer);
 
     assertEquals(indices, instance.getIndices());
     assertEquals(values, instance.getValues());
@@ -80,7 +80,7 @@ class DoubleSparseNdArrayTest {
     DoubleDataBuffer dataBuffer = RawDataBufferFactory.create(denseArrayDefaultValue, false);
     // use a zero buffer
     DoubleSparseNdArray instance = DoubleSparseNdArray.create(-1d, DimensionalSpace.create(shape));
-    instance.write(dataBuffer);
+    instance.copyFrom(dataBuffer);
 
     assertEquals(indices, instance.getIndices());
     assertEquals(values, instance.getValues());
@@ -266,7 +266,7 @@ class DoubleSparseNdArrayTest {
     DoubleDataBuffer dataBuffer = RawDataBufferFactory.create(denseArray, false);
     // use a zero buffer
     DoubleSparseNdArray instanceB = DoubleSparseNdArray.create(DimensionalSpace.create(shape));
-    instanceB.write(dataBuffer);
+    instanceB.copyFrom(dataBuffer);
     assertEquals(instance, instanceB);
 
     DoubleSparseNdArray instanceC =

--- a/ndarray/src/test/java/org/tensorflow/ndarray/impl/sparse/FloatSparseNdArrayTest.java
+++ b/ndarray/src/test/java/org/tensorflow/ndarray/impl/sparse/FloatSparseNdArrayTest.java
@@ -46,12 +46,12 @@ class FloatSparseNdArrayTest {
   }
 
   @Test
-  public void testRead() {
+  public void testCopyToBuffer() {
     FloatSparseNdArray instance =
         new FloatSparseNdArray(indices, values, DimensionalSpace.create(shape));
     FloatDataBuffer dataBuffer = DataBuffers.ofFloats(instance.shape().size());
 
-    instance.read(dataBuffer);
+    instance.copyTo(dataBuffer);
 
     float[] array = new float[denseArray.length];
     dataBuffer.read(array);
@@ -59,12 +59,12 @@ class FloatSparseNdArrayTest {
   }
 
   @Test
-  public void testWrite() {
+  public void testCopyFromBuffer() {
 
     FloatDataBuffer dataBuffer = NioDataBufferFactory.create(FloatBuffer.wrap(denseArray));
     // use a zero buffer
     FloatSparseNdArray instance = FloatSparseNdArray.create(DimensionalSpace.create(shape));
-    instance.write(dataBuffer);
+    instance.copyFrom(dataBuffer);
 
     assertEquals(indices, instance.getIndices());
     assertEquals(values, instance.getValues());
@@ -80,7 +80,7 @@ class FloatSparseNdArrayTest {
     FloatDataBuffer dataBuffer = RawDataBufferFactory.create(denseArrayDefaultValue, false);
     // use a zero buffer
     FloatSparseNdArray instance = FloatSparseNdArray.create(-1f, DimensionalSpace.create(shape));
-    instance.write(dataBuffer);
+    instance.copyFrom(dataBuffer);
 
     assertEquals(indices, instance.getIndices());
     assertEquals(values, instance.getValues());
@@ -274,7 +274,7 @@ class FloatSparseNdArrayTest {
     FloatDataBuffer dataBuffer = RawDataBufferFactory.create(denseArray, false);
     // use a zero buffer
     FloatSparseNdArray instanceB = FloatSparseNdArray.create(DimensionalSpace.create(shape));
-    instanceB.write(dataBuffer);
+    instanceB.copyFrom(dataBuffer);
     assertEquals(instance, instanceB);
 
     FloatSparseNdArray instanceC =

--- a/ndarray/src/test/java/org/tensorflow/ndarray/impl/sparse/IntSparseNdArrayTest.java
+++ b/ndarray/src/test/java/org/tensorflow/ndarray/impl/sparse/IntSparseNdArrayTest.java
@@ -47,12 +47,12 @@ class IntSparseNdArrayTest {
   }
 
   @Test
-  public void testRead() {
+  public void testCopyToBuffer() {
     IntSparseNdArray instance =
         new IntSparseNdArray(indices, values, DimensionalSpace.create(shape));
     IntDataBuffer dataBuffer = DataBuffers.ofInts(instance.shape().size());
 
-    instance.read(dataBuffer);
+    instance.copyTo(dataBuffer);
 
     int[] array = new int[denseArray.length];
     dataBuffer.read(array);
@@ -60,12 +60,12 @@ class IntSparseNdArrayTest {
   }
 
   @Test
-  public void testWrite() {
+  public void testCopyFromBufferBuffer() {
 
     IntDataBuffer dataBuffer = NioDataBufferFactory.create(IntBuffer.wrap(denseArray));
     // use a zero buffer
     IntSparseNdArray instance = IntSparseNdArray.create(DimensionalSpace.create(shape));
-    instance.write(dataBuffer);
+    instance.copyFrom(dataBuffer);
 
     assertEquals(indices, instance.getIndices());
     assertEquals(values, instance.getValues());
@@ -79,7 +79,7 @@ class IntSparseNdArrayTest {
     IntDataBuffer dataBuffer = RawDataBufferFactory.create(denseArrayDefaultValue, false);
     // use a zero buffer
     IntSparseNdArray instance = IntSparseNdArray.create(-1, DimensionalSpace.create(shape));
-    instance.write(dataBuffer);
+    instance.copyFrom(dataBuffer);
 
     assertEquals(indices, instance.getIndices());
     assertEquals(values, instance.getValues());
@@ -272,7 +272,7 @@ class IntSparseNdArrayTest {
     IntDataBuffer dataBuffer = RawDataBufferFactory.create(denseArray, false);
     // use a zero buffer
     IntSparseNdArray instanceB = IntSparseNdArray.create(DimensionalSpace.create(shape));
-    instanceB.write(dataBuffer);
+    instanceB.copyFrom(dataBuffer);
     assertEquals(instance, instanceB);
 
     IntSparseNdArray instanceC =

--- a/ndarray/src/test/java/org/tensorflow/ndarray/impl/sparse/LongSparseNdArrayTest.java
+++ b/ndarray/src/test/java/org/tensorflow/ndarray/impl/sparse/LongSparseNdArrayTest.java
@@ -46,12 +46,12 @@ class LongSparseNdArrayTest {
   }
 
   @Test
-  public void testRead() {
+  public void testCopyToBuffer() {
     LongSparseNdArray instance =
         new LongSparseNdArray(indices, values, DimensionalSpace.create(shape));
     LongDataBuffer dataBuffer = DataBuffers.ofLongs(instance.shape().size());
 
-    instance.read(dataBuffer);
+    instance.copyTo(dataBuffer);
 
     long[] array = new long[denseArray.length];
     dataBuffer.read(array);
@@ -59,12 +59,12 @@ class LongSparseNdArrayTest {
   }
 
   @Test
-  public void testWrite() {
+  public void testCopyFromBuffer() {
 
     LongDataBuffer dataBuffer = NioDataBufferFactory.create(LongBuffer.wrap(denseArray));
     // use a zero buffer
     LongSparseNdArray instance = LongSparseNdArray.create(DimensionalSpace.create(shape));
-    instance.write(dataBuffer);
+    instance.copyFrom(dataBuffer);
 
     assertEquals(indices, instance.getIndices());
     assertEquals(values, instance.getValues());
@@ -78,7 +78,7 @@ class LongSparseNdArrayTest {
     LongDataBuffer dataBuffer = RawDataBufferFactory.create(denseArrayDefaultValue, false);
     // use a zero buffer
     LongSparseNdArray instance = LongSparseNdArray.create(-1L, DimensionalSpace.create(shape));
-    instance.write(dataBuffer);
+    instance.copyFrom(dataBuffer);
 
     assertEquals(indices, instance.getIndices());
     assertEquals(values, instance.getValues());
@@ -271,7 +271,7 @@ class LongSparseNdArrayTest {
     LongDataBuffer dataBuffer = RawDataBufferFactory.create(denseArray, false);
     // use a zero buffer
     LongSparseNdArray instanceB = LongSparseNdArray.create(DimensionalSpace.create(shape));
-    instanceB.write(dataBuffer);
+    instanceB.copyFrom(dataBuffer);
     assertEquals(instance, instanceB);
 
     LongSparseNdArray instanceC =

--- a/ndarray/src/test/java/org/tensorflow/ndarray/impl/sparse/ShortSparseNdArrayTest.java
+++ b/ndarray/src/test/java/org/tensorflow/ndarray/impl/sparse/ShortSparseNdArrayTest.java
@@ -45,12 +45,12 @@ class ShortSparseNdArrayTest {
   }
 
   @Test
-  public void testRead() {
+  public void testCopyToBuffer() {
     ShortSparseNdArray instance =
         new ShortSparseNdArray(indices, values, DimensionalSpace.create(shape));
     ShortDataBuffer dataBuffer = DataBuffers.ofShorts(instance.shape().size());
 
-    instance.read(dataBuffer);
+    instance.copyTo(dataBuffer);
 
     short[] array = new short[denseArray.length];
     dataBuffer.read(array);
@@ -58,12 +58,12 @@ class ShortSparseNdArrayTest {
   }
 
   @Test
-  public void testWrite() {
+  public void testCopyFromBuffer() {
 
     ShortDataBuffer dataBuffer = NioDataBufferFactory.create(ShortBuffer.wrap(denseArray));
     // use a zero buffer
     ShortSparseNdArray instance = ShortSparseNdArray.create(DimensionalSpace.create(shape));
-    instance.write(dataBuffer);
+    instance.copyFrom(dataBuffer);
 
     assertEquals(indices, instance.getIndices());
     assertEquals(values, instance.getValues());
@@ -81,7 +81,7 @@ class ShortSparseNdArrayTest {
     // use a zero buffer
     ShortSparseNdArray instance =
         ShortSparseNdArray.create((short) -1, DimensionalSpace.create(shape));
-    instance.write(dataBuffer);
+    instance.copyFrom(dataBuffer);
 
     assertEquals(indices, instance.getIndices());
     assertEquals(values, instance.getValues());
@@ -275,7 +275,7 @@ class ShortSparseNdArrayTest {
     ShortDataBuffer dataBuffer = RawDataBufferFactory.create(denseArray, false);
     // use a zero buffer
     ShortSparseNdArray instanceB = ShortSparseNdArray.create(DimensionalSpace.create(shape));
-    instanceB.write(dataBuffer);
+    instanceB.copyFrom(dataBuffer);
     assertEquals(instance, instanceB);
 
     ShortSparseNdArray instanceC =

--- a/ndarray/src/test/java/org/tensorflow/ndarray/impl/sparse/StringSparseNdArrayTest.java
+++ b/ndarray/src/test/java/org/tensorflow/ndarray/impl/sparse/StringSparseNdArrayTest.java
@@ -64,12 +64,12 @@ public class StringSparseNdArrayTest {
   }
 
   @Test
-  public void testRead() {
+  public void testCopyToBuffer() {
     SparseNdArray<String, NdArray<String>> instance =
         new SparseNdArray<>(String.class, indices, values, DimensionalSpace.create(shape));
     DataBuffer<String> dataBuffer = DataBuffers.ofObjects(String.class, instance.shape().size());
 
-    instance.read(dataBuffer);
+    instance.copyTo(dataBuffer);
 
     String[] array = new String[denseArray.length];
     dataBuffer.read(array);
@@ -77,13 +77,13 @@ public class StringSparseNdArrayTest {
   }
 
   @Test
-  public void testWrite() {
+  public void testCopyFromBuffer() {
 
     DataBuffer<String> dataBuffer = DataBuffers.ofObjects(denseArray);
     // use a zero buffer
     SparseNdArray<String, NdArray<String>> instance =
         SparseNdArray.create(String.class, DimensionalSpace.create(shape));
-    instance.write(dataBuffer);
+    instance.copyFrom(dataBuffer);
 
     assertEquals(indices, instance.getIndices());
     assertEquals(values, instance.getValues());
@@ -103,7 +103,7 @@ public class StringSparseNdArrayTest {
     // use a zero buffer
     SparseNdArray<String, NdArray<String>> instance =
         SparseNdArray.create(String.class, defaultValue, DimensionalSpace.create(shape));
-    instance.write(dataBuffer);
+    instance.copyFrom(dataBuffer);
 
     assertEquals(indices, instance.getIndices());
     assertEquals(values, instance.getValues());
@@ -282,7 +282,7 @@ public class StringSparseNdArrayTest {
     // use a zero buffer
     SparseNdArray<String, NdArray<String>> instanceB =
         SparseNdArray.create(String.class, DimensionalSpace.create(shape));
-    instanceB.write(dataBuffer);
+    instanceB.copyFrom(dataBuffer);
     assertEquals(instance, instanceB);
 
     SparseNdArray<String, NdArray<String>> instanceC =


### PR DESCRIPTION
Renames `NdArray.read(dstBuffer)` to `NdArray.copyTo(dstBuffer)`, and `NdArray.write(srcBuffer)` to `NdArray.copyFrom(srcBuffer)`, to make more obvious the direction of the data flow of these methods.

This is somehow related to https://github.com/tensorflow/java/issues/510, though I just modified the signature in `NdArray` and left the one in `DataBuffer` intact, since the `read/write` methods of these entities tries to replicate the behaviour of the `get/put` methods of the Java NIO buffers.